### PR TITLE
fix(site): cleanup audit findings (FAQ + privacy footer)

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -114,12 +114,12 @@
 
           <div>
             <h3 class="font-semibold text-navy mb-2">How long does a typical engagement take?</h3>
-            <p class="text-gray-600 leading-relaxed">It depends on the scope. A strategy and roadmap engagement typically takes 1–2 weeks. Implementation projects range from a few days to a few weeks depending on complexity. The fractional advisor retainer is ongoing month-to-month.</p>
+            <p class="text-gray-600 leading-relaxed">It depends on which track. A Track 1 audit is typically 1–2 weeks. Track 1 builds range from a few days to a few weeks depending on complexity. Track 2 training sessions and workshops are scheduled per engagement. Track 3 builds are scoped per project. Monthly retainers (dev support, training, or automation maintenance) are ongoing month-to-month.</p>
           </div>
 
           <div>
             <h3 class="font-semibold text-navy mb-2">Do you require long-term contracts?</h3>
-            <p class="text-gray-600 leading-relaxed">No. Project engagements are fixed-scope and fixed-price. The fractional advisor retainer is month-to-month with no lock-in — cancel any time.</p>
+            <p class="text-gray-600 leading-relaxed">No. Project engagements are fixed-scope and fixed-price. Retainers (Track 1 ongoing support, Track 2 training, or Track 3 automation maintenance) are month-to-month with no lock-in — cancel any time.</p>
           </div>
 
         </div>

--- a/privacy.html
+++ b/privacy.html
@@ -145,6 +145,7 @@
             <li><a href="faq.html" class="text-gray-300 hover:text-gold transition-colors duration-200">FAQ</a></li>
             <li><a href="contact.html" class="text-gray-300 hover:text-gold transition-colors duration-200">Contact</a></li>
             <li><a href="privacy.html" class="text-gray-300 hover:text-gold transition-colors duration-200">Privacy Policy</a></li>
+            <li><a href="https://admin.williamtucker.ca/login" class="text-gray-300 hover:text-gold transition-colors duration-200">Client Portal</a></li>
           </ul>
         </div>
         <div>


### PR DESCRIPTION
## Summary

Two small consistency fixes surfaced by the post-merge cross-page audit. Originally drafted on the reframe branch; landed on master via PR #3 (`feat/contact-to-wtsadmin`) before this fix was pushed.

- **faq.html**: Two "fractional advisor retainer" references replaced with three-track-aware language (left over from dual-track positioning).
- **privacy.html**: Added missing Client Portal link to footer Quick Links (every other page has it).

Single commit: `a77648b`.

## Test plan

- [x] `npm run check:claims` — 0 violations
- [x] `npm run build` — succeeds
- [ ] Visual review of `/faq.html` (the two updated answers) and `/privacy.html` (footer Client Portal link)

🤖 Generated with [Claude Code](https://claude.com/claude-code)