### PR TITLE
docs: bootstrap docs vault + sync stale top-level docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,26 @@
 This file orients agents working in `D:\code\WTS` (the William Tucker
 Solutions marketing site). Read it before editing any copy.
 
+## Read the vault first
+
+This project has a documentation vault at `docs/` — start there before
+guessing anything about architecture, deploy, contact-form, or
+positioning. The vault is the authoritative source for codebase facts;
+this CLAUDE.md is just orientation.
+
+- **`docs/_index.md`** — vault home; lists every domain doc with
+  one-line task hints. Read this before grepping the repo.
+- **`docs/_meta/vault-conventions.md`** — REQUIRED before editing any
+  doc under `docs/`.
+- **`docs/_meta/docs-sync-prompt.md`** — REQUIRED when the user says
+  "update docs" / "sync docs".
+
+If you're debugging a failure mode and a domain doc seems relevant
+(e.g., deploy caching, linter behavior, contact-form handler), read
+that doc end-to-end before guessing. The vault was created on
+2026-05-18 after a 3-hour cache-debugging incident that a 5-minute
+read of a deploy doc would have prevented.
+
 ## Source of truth
 
 - **`D:\code\cv\PROFILE.md` is canonical** for every fact about William's
@@ -57,24 +77,32 @@ cannot recur.
 
 ## Other places facts and rules live
 
-| Topic | Where |
-|---|---|
-| Brand voice / positioning | `PRODUCT.md` |
-| Visual spec, anti-references | `DESIGN.md` + `DESIGN.json` |
-| Chatbot system prompt | `server.js:28-194` (sync hazard — see below) |
-| Deploy / launch process | `docs/launch-guide.md` |
-| Sales materials | `docs/sales/` |
-| Funding / grants | `GRANTS.md` |
-| Known drift / TODOs | `docs/_backlog.md` |
-| Linter pattern catalog | `scripts/check-claims.mjs` |
+For full docs use the vault. Quick-reference:
+
+| Topic | Vault doc | Other |
+|---|---|---|
+| Three tracks / brand voice / framing rules | `docs/positioning.md` | `PRODUCT.md` (legacy — being migrated) |
+| HTML page map / anchor naming / breakpoints | `docs/pages.md` | — |
+| Linter patterns / suppressions / build integration | `docs/linter.md` | `scripts/check-claims.mjs` |
+| GitHub Actions → DreamHost / Cloudflare / cache-busting | `docs/deploy.md` | `.github/workflows/deploy.yml` |
+| `/api/contact` flow / Supabase / Turnstile / Resend | `docs/contact-flow.md` | `server.js`, `.env.example` |
+| Visual system (colors, type, components) | `docs/visual-system.md` (stub) | `DESIGN.md` + `DESIGN.json` (current source) |
+| Chatbot prompt / `/api/chat` / widget | `docs/chatbot.md` (stub) | `prompts/chatbot-system.md` (loaded by `server.js` at startup) |
+| Known drift / TODO-verify | `docs/_backlog.md` | — |
+
+Local-only / off-site:
+- Launch process: `docs/launch-guide.md` (gitignored — local only)
+- Sales materials: `docs/sales/` (gitignored — local only)
+- Funding / grants: `GRANTS.md` (gitignored — local only)
 
 ## Two surfaces, one source of truth
 
-HTML page copy AND `server.js:28-194` (the chatbot system prompt) both
-restate facts that originate in `PROFILE.md`. When PROFILE.md changes,
-both surfaces must be updated together. The linter scans both. A future
-task — logged in `docs/_backlog.md` — will extract the system prompt to
-`prompts/chatbot-system.md` so it can be edited as plain prose.
+HTML page copy AND `prompts/chatbot-system.md` (the chatbot system
+prompt — loaded by `server.js` at startup) both restate facts that
+originate in `PROFILE.md`. When PROFILE.md changes, both surfaces
+must be updated together. The linter scans both. Pricing numbers,
+in particular, must match exactly between `pricing.html` and the
+prompt — see `docs/positioning.md` for the discipline.
 
 ## Project shape
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,6 +1,6 @@
 ---
 name: William Tucker Solutions
-description: Marketing site for a one-engineer consulting practice (legacy modernization + AI consulting).
+description: Marketing site for a one-engineer consulting practice (AI-accelerated software development, AI training, AI workflow automation).
 colors:
   drafting-navy: "#1a2332"
   drafting-navy-light: "#243044"

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,24 +1,28 @@
 # Product
 
+> **Note:** the deep version of this doc — the three tracks, framing rules, audience, anti-references — lives in the docs vault at `docs/positioning.md`. Read that for the canonical, code-cited treatment. This file remains as the brand-voice / design-principles / accessibility quick reference.
+
 ## Register
 
 brand
 
 ## Users
 
-The site fishes for two distinct buyer tracks, and is intentionally scoped wide because William has no signed clients yet and is testing where revenue lands first.
+Referral-driven Kelowna SMB-first. Most visitors arrive via referral; the site is service confirmation + booking, not credibility argument.
 
-**Track A — Legacy modernization.** Decision-maker inside an organization stuck on .NET, Classic ASP, Oracle PL/SQL, or comparable older stacks. Likely titles: IT director, head of applications, CTO at a small org, or the senior dev who has been quietly rewriting the same system for five years. They have been quoted by traditional consultancies in months and six-figure ranges. They arrive skeptical that "AI-accelerated" means anything real.
+Three service tracks (full detail in `docs/positioning.md`):
 
-**Track B — AI consulting for finance teams and small businesses.** Finance manager, controller, or owner-operator who has heard about AI but has been burned by hype, by slide-deck firms, or by tools that did not survive contact with their actual workflow. They want working software, not a strategy deck.
+1. **AI-Accelerated Software Development** — custom software, modernizations, enhancements. AI handles boilerplate; William handles engineering and review.
+2. **AI Training** — 1:1, group workshops, custom curriculum. In-person Kelowna or online. From a daily practitioner, not a credentialled trainer.
+3. **AI Workflow Automation** — chatbots, custom integrations, internal tooling. AI plugged into systems the client already uses.
 
-Both tracks share a posture: they trust evidence over claims, and they have already filtered out the obvious AI-hype consultancies before landing here.
+The previous dual-track structure ("Legacy modernization" + "AI consulting for finance teams") was retired in PR #4 (2026-05-15). Don't reintroduce it.
 
 ## Product Purpose
 
-Convert a one-person consulting practice (William Tucker Solutions) into booked discovery calls. The site is the entire top-of-funnel — there is no paid acquisition, no sales team, no SDR. Every page has to earn the call by itself.
+Convert a one-engineer consulting practice (William Tucker Solutions) into booked discovery calls. The site is the entire top-of-funnel — there is no paid acquisition, no sales team, no SDR. Most clients arrive via referral.
 
-Success is a discovery call booked by a buyer who already understands which track applies to them and arrives with a real project, not a vague "tell me about AI" inquiry.
+Success is a discovery call booked by a referral-warm visitor who picked the right track from the three above and arrives with a real project, not a vague "tell me about AI" inquiry.
 
 ## Brand Personality
 
@@ -52,7 +56,7 @@ The connecting thread is decoration without referent. WTS visuals must read as p
 2. **No hype, no slide decks.** Direct from the site's own positioning. The aesthetic must reinforce this: no gradient text, no glassmorphism, no decorative AI imagery, no animated count-ups, no "transformation journey" diagrams.
 3. **Solo-engineer credibility.** A one-person practice cannot fake enterprise-scale theater, and the design should not try. Tight typography, real names, real timelines, modest scale. Boutique, not boutique-pretending-to-be-enterprise.
 4. **Senior-engineer voice.** Copy reads as one technical professional talking to another. No marketing-speak, no first-person-plural ("our team"), no future-tense vague promises. Present tense, specific verbs, concrete nouns.
-5. **Wide net, sharp evidence.** The site fishes for two distinct buyer tracks, so navigation and entry points must serve both without diluting either. Each track gets its own dedicated proof, not a generic shared frame.
+5. **Wide net, sharp evidence.** The site offers three service tracks, so navigation and entry points must serve all three without diluting any of them. Each track gets its own dedicated section, not a generic shared frame.
 
 ## Accessibility & Inclusion
 

--- a/docs/_backlog.md
+++ b/docs/_backlog.md
@@ -1,7 +1,8 @@
 ---
 title: WTS Backlog
+domain: meta
 status: active
-last-reviewed: 2026-05-06
+last-reviewed: 2026-05-18
 ---
 
 # WTS Backlog

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -1,0 +1,72 @@
+---
+title: Documentation Vault — Home
+domain: meta
+status: active
+last-reviewed: 2026-05-18
+---
+
+# Documentation Vault
+
+**For AI agents and humans.** This is the root of the docs vault. Start here.
+
+> If you are an agent working in this repo, read this note first, then the specific domain doc for your task. Do not grep the whole vault — domain docs are designed to be read directly.
+
+---
+
+## Scope
+
+This vault documents the **williamtucker.ca marketing site** for William Tucker Solutions (WTS) — a one-engineer consulting practice based in Kelowna, BC. The site is a static HTML + Tailwind CSS v4 site with a small Node/Express server (`server.js`) that handles the chatbot proxy (`/api/chat`) and contact-form lead intake (`/api/contact`). Deployed to DreamHost via GitHub Actions; the server runs on Railway. Cloudflare sits in front of the public domain.
+
+Per-feature design history (specs, plans, ADRs) lives under `docs/superpowers/` and is out of scope here.
+
+---
+
+## Domain docs
+
+| Task context | Doc |
+|---|---|
+| Editing copy, positioning, three-track framing, brand-voice rules | [[positioning]] |
+| Working on any HTML page — structure, anchor naming, mobile breakpoints, nav patterns | [[pages]] |
+| Adding/changing claim-linter patterns, suppression comments, debugging linter failures | [[linter]] |
+| Deploying, debugging cache issues, CSS cache-busting, GitHub Actions, Cloudflare CDN | [[deploy]] |
+| Contact form, `/api/contact` endpoint, WTSAdmin/Supabase integration, Turnstile, Resend | [[contact-flow]] |
+| Colors, typography, components, visual elevation, anti-references (stub — extract from DESIGN.md when first edited) | [[visual-system]] |
+| Chatbot prompt content, `/api/chat` endpoint, chatbot widget JS (stub — extract from chatbot work when first edited) | [[chatbot]] |
+
+---
+
+## Cheatsheets
+
+`docs/_cheatsheets/` holds ≤50-line quick-references for high-frequency lookups whose answers are buried in 300+ line domain docs. None yet — add as repetitive lookups emerge.
+
+| Lookup | Cheatsheet | Parent doc |
+|---|---|---|
+| _(none yet)_ | | |
+
+---
+
+## Machinery
+
+- [[vault-conventions]] — the playbook (naming, frontmatter, verification rules)
+- [docs/_meta/doc-ownership.yml](_meta/doc-ownership.yml) — code-path → doc map consumed by `scripts/match-docs.mjs`
+- [[docs-sync-prompt]] — the workflow followed when you say "update docs"
+- [[_backlog]] — gaps, TODO-verify flags, undocumented behavior
+
+---
+
+## Conventions (see [[vault-conventions]] for full detail)
+
+- Filenames: `kebab-case.md`
+- Wikilinks: `[[filename]]` or `[[filename#section]]`
+- Every doc: frontmatter with `title`, `domain`, `status`, `last-reviewed`, and (for verification-citing docs) `verified-against`
+- Code citations include `file:line` anchors
+- Schema/API/live-behavior content verified against ground truth at write time
+- Archive, don't delete
+
+---
+
+## Source-of-truth hierarchy
+
+The vault is the place to record what's true about THIS codebase. For facts about William's career, projects, employment history, and credentials, the canonical source is `D:\code\cv\PROFILE.md` (outside this repo). Vault docs may reference PROFILE.md but should not duplicate it.
+
+`CLAUDE.md` at the repo root is the agent-orientation entry point and pointer to this vault. Workspace-level `D:\code\CLAUDE.md` framing rules apply to all WTS work.

--- a/docs/_meta/doc-ownership.yml
+++ b/docs/_meta/doc-ownership.yml
@@ -1,0 +1,100 @@
+# doc-ownership.yml — code-path → doc routing map.
+#
+# Consumed by `scripts/match-docs.mjs` to determine which docs are affected
+# by a given diff. Edit this file to map your code paths to your domain docs.
+#
+# Notes:
+# - A file can be matched by multiple docs. The script reports it under each.
+# - A file matched by NO doc is reported as "unmatched" — handle in step 3 of
+#   the sync workflow (add ownership, or confirm it legitimately has no owner).
+# - Globs are evaluated relative to the repo root.
+
+docs:
+
+  positioning:
+    paths:
+      - 'PRODUCT.md'
+      - '*.html'  # any HTML page-copy edit can touch positioning
+    concepts:
+      - 'three-track'
+      - 'AI-accelerated'
+      - 'AI-Accelerated Software Development'
+      - 'AI Training'
+      - 'AI Workflow Automation'
+      - 'Kelowna'
+      - '12+ years'
+      - 'RoomBooking'
+      - 'BIS'
+
+  pages:
+    paths:
+      - '*.html'
+      - 'js/*.js'
+    concepts:
+      - 'class="hidden md:flex'  # nav markers
+      - 'mobile-menu'
+      - 'sticky top-0'
+      - 'order-1'
+      - 'order-2'
+      - 'md:order-'
+
+  linter:
+    paths:
+      - 'scripts/check-claims.mjs'
+      - 'tests/check-claims.test.mjs'
+    concepts:
+      - 'PATTERNS'
+      - 'check-claims-allow'
+      - 'checkLine'
+      - 'checkProximity'
+
+  deploy:
+    paths:
+      - '.github/workflows/**'
+      - 'package.json'
+      - 'css/styles.css'  # cache-buster discipline lives here
+    concepts:
+      - 'rsync'
+      - 'DREAMHOST_SSH_KEY'
+      - 'Cloudflare'
+      - 'cache-buster'
+      - '?v=2026'
+      - 'check:claims'
+      - 'tailwindcss'
+
+  contact-flow:
+    paths:
+      - 'contact.html'
+      - 'server.js'
+      - '.env.example'
+    concepts:
+      - '/api/contact'
+      - 'Turnstile'
+      - 'Resend'
+      - 'wts_contact'
+      - 'SUPABASE_SERVICE_ROLE_KEY'
+
+  visual-system:
+    paths:
+      - 'DESIGN.md'
+      - 'DESIGN.json'
+      - 'src/input.css'
+      - 'css/styles.css'
+      - 'tailwind.config.js'
+    concepts:
+      - '--color-gold'
+      - '--color-navy'
+      - 'Solder Gold'
+      - 'Drafting Navy'
+
+  chatbot:
+    paths:
+      - 'prompts/chatbot-system.md'
+      - 'server.js'
+      - 'js/chatbot.js'
+      - 'js/chatbot-demo.js'
+    concepts:
+      - '/api/chat'
+      - 'SYSTEM_PROMPT'
+      - 'Anthropic'
+      - 'claude-'

--- a/docs/_meta/docs-sync-prompt.md
+++ b/docs/_meta/docs-sync-prompt.md
@@ -1,0 +1,101 @@
+---
+title: Docs Sync Prompt
+domain: meta
+status: active
+last-reviewed: 2026-05-18
+---
+
+# Docs Sync Prompt
+
+When the user says "update docs" or "sync docs", follow these steps. This is the local workflow for keeping domain docs fresh — usually before merging a feature branch.
+
+> If you have the `sync-ai-docs` skill installed in Claude Code, that skill mirrors this workflow. This in-repo copy lets contributors without the skill follow the same steps.
+
+## Step 1 — Determine the diff base
+
+Ask the user (or infer from context):
+
+- On a feature branch about to merge: base is `master...HEAD` (or `main...HEAD`).
+- Just merged into master: base is `HEAD~1 HEAD`.
+- User specifies a base ref: use that.
+
+## Step 2 — Run the routing script
+
+```bash
+node scripts/match-docs.mjs <base-ref>
+```
+
+This writes:
+
+- `affected-docs.txt` — newline-separated list of doc filenames to update.
+- `match-summary.md` — human-readable explanation of which files changed and which docs are affected.
+
+Read both.
+
+## Step 3 — Handle unmatched files
+
+If `match-summary.md` lists unmatched files (files that changed but no doc owns), do not proceed silently. Options:
+
+- Add the paths to `docs/_meta/doc-ownership.yml` under the right doc, then re-run the script.
+- Confirm with the user that these files genuinely don't belong to any doc.
+
+## Step 4 — Refresh memory of conventions
+
+Re-read `docs/_meta/vault-conventions.md`. Specifically:
+
+- Frontmatter requirements.
+- The "What's in / What's NOT" callout format.
+- Section-level `verified-against` HTML comments.
+- `file:line` anchors in code citations.
+- Mermaid diagram threshold.
+
+## Step 5 — For each affected doc, update it
+
+For each doc in `affected-docs.txt`:
+
+1. Read the current doc.
+2. Read the changed code files routed to this doc.
+3. If the doc has `verified-against:` frontmatter pointing at schema/API/live behavior, re-run the underlying queries. Diff results against current claims.
+4. Edit the doc to reflect actual behavior:
+   - Update sections describing changed code (with new `file:line` anchors).
+   - Update schema/API tables if columns/types changed.
+   - Update sequence diagrams if flow changed.
+   - Bump `last-reviewed` to today's date.
+   - Add new migrations/specs/queries to `verified-against:` if load-bearing.
+5. If a section cannot be verified, append `TODO verify: <what>` to `docs/_backlog.md`. Do not guess.
+
+## Step 6 — Do not invent content
+
+If the merge adds behavior with no existing doc section:
+
+- Append a `## TODO: <feature-name>` stub to the right doc.
+- Add a matching entry to `docs/_backlog.md`.
+- Tell the user: "Merge introduces new behavior with no existing doc section. Stub added; fill in manually in a dedicated writing session."
+
+Do not hallucinate a full section.
+
+## Step 7 — Summarize
+
+Report back in a compact bullet list:
+
+- Which docs were updated (with line-count diff).
+- What new entries went into `_backlog.md`.
+- Any unmatched files the user must decide about.
+- Any verification queries that failed.
+
+## What NOT to do
+
+- Do not touch files outside `docs/**` and `docs/_backlog.md`.
+- Do not modify code to "match the docs."
+- Do not remove sections the code no longer supports — append `(removed YYYY-MM-DD)` and move to `_archive/` on a future pass.
+- Do not write long narrative prose without a code citation or verification anchor backing each claim.
+- Do not skip Step 3 (unmatched files) silently — that's how vaults rot.
+
+## Common rationalizations to refuse
+
+| Excuse | Reality |
+|---|---|
+| "The code change is small, docs probably aren't affected" | Run the routing script anyway. It takes 2 seconds. |
+| "I'll re-verify the schema later" | Later = never. Re-verify now or add a `TODO verify` to `_backlog.md`. |
+| "The unmatched file is obviously just a config tweak" | Confirm with the user before skipping. Configs become load-bearing. |
+| "I can paraphrase the existing doc to match the new code" | No. Re-verify against ground truth. Paraphrasing is how docs hallucinate. |

--- a/docs/_meta/templates/cheatsheet.md
+++ b/docs/_meta/templates/cheatsheet.md
@@ -1,0 +1,21 @@
+---
+title: REPLACE_WITH_CHEATSHEET_TITLE
+domain: cheatsheet
+status: active
+last-reviewed: 2026-05-18
+---
+
+# REPLACE_WITH_CHEATSHEET_TITLE
+
+> **Quick lookup only.** ≤50 lines. For full reasoning see [[REPLACE_WITH_PARENT_DOC]]. <!-- vault-doctor: ignore -->
+
+## REPLACE_WITH_LOOKUP_HEADING
+
+| REPLACE_WITH_COLUMN_1 | REPLACE_WITH_COLUMN_2 | REPLACE_WITH_COLUMN_3 |
+|---|---|---|
+| ... | ... | ... |
+
+## When to escalate to the full doc
+
+- REPLACE_WITH_CONDITION (e.g. "the question involves more than just lookup")
+- REPLACE_WITH_CONDITION (e.g. "you need the *why*, not just the *what*")

--- a/docs/_meta/templates/domain-doc.md
+++ b/docs/_meta/templates/domain-doc.md
@@ -1,0 +1,49 @@
+---
+title: REPLACE_WITH_TITLE
+domain: REPLACE_WITH_DOMAIN_SLUG
+status: active
+last-reviewed: 2026-05-18
+verified-against:
+  # Add entries here only if this doc cites schema/API/live behavior.
+  # Examples:
+  #   - migration: 042_add_user_preferences.sql
+  #   - mcp-query: list_tables(schemas=["public"])
+  #   - api-spec: openapi.yaml
+---
+
+# REPLACE_WITH_TITLE
+
+> **What's in this doc:** REPLACE_WITH_ONE_SENTENCE_LIST_OF_COVERED_TOPICS.
+>
+> **What's NOT:** REPLACE_WITH_EXCLUSIONS_AND_WIKILINKS_TO_OTHER_DOCS.
+
+## REPLACE_WITH_FIRST_SECTION_HEADING
+
+REPLACE_WITH_PROSE.
+
+Cite code by `file:line`:
+
+> Example: the request handler at `src/api/foo.ts:42` validates the body before calling `validateUser()` at `src/lib/auth.ts:118`.
+
+If this section crosses ≥2 layers, open with a mermaid sequence diagram:
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant API
+    participant DB
+    Client->>API: POST /foo
+    API->>DB: insert
+    DB-->>API: row
+    API-->>Client: 201
+```
+
+## REPLACE_WITH_SECOND_SECTION (if it cites schema/API/live behavior)
+
+> Verified against REPLACE_WITH_SOURCE_OF_TRUTH on 2026-05-18.
+
+| column | type | notes |
+|---|---|---|
+| ... | ... | ... |
+
+<!-- verified-against: <exact query or query-summary> on 2026-05-18 -->

--- a/docs/_meta/vault-conventions.md
+++ b/docs/_meta/vault-conventions.md
@@ -1,0 +1,182 @@
+---
+title: Vault Conventions
+domain: meta
+status: active
+last-reviewed: 2026-05-18
+---
+
+# Vault Conventions
+
+> **What's in this doc:** filename rules, required frontmatter, doc anatomy (the "What's in / What's NOT" callout), wikilink syntax, code-citation conventions, schema/API/live-behavior verification rules, mermaid diagram threshold, TOC threshold, archive policy, backlog conventions, the "touching a doc" checklist.
+>
+> **What's NOT:** the "update docs" / "sync docs" workflow (→ [[docs-sync-prompt]]), the code-path routing map (→ `_meta/doc-ownership.yml`), per-feature design history (specs, plans, ADRs — those have their own conventions outside this vault).
+
+The rules for writing and maintaining docs in this vault. This is the playbook.
+
+> **Scope:** the domain docs under `docs/` and their index/meta files. Does NOT govern per-feature design history (specs, plans, ADRs).
+
+## Core principles
+
+1. **Verify before writing.** Any claim about schema, RLS, API shape, or live behavior must be checked against the source of truth at write time (DB introspection, OpenAPI spec, MCP query, `kubectl get`, whatever the project uses). Never paraphrase from memory or older docs.
+2. **Cite by `file:line`, not `file`.** `app/api/auth/route.ts:42` beats `app/api/auth/route.ts`. The line number is the difference between "I know roughly where this is" and "I can jump there."
+3. **Open with What's in / What's NOT.** Every doc starts with a callout listing what it covers AND what it doesn't (with wikilinks to the docs that DO cover the excluded topics). Lets an agent confirm it's in the right doc in two lines.
+4. **Archive, don't delete.** Obsolete docs move to `docs/_archive/` with `superseded-by:` frontmatter. Backlinks from older specs/plans stay valid.
+5. **Bump `last-reviewed` on every edit.** It's the only signal an agent has for whether to trust the doc.
+
+## Filenames
+
+- `kebab-case.md`. No spaces, no SCREAMING_SNAKE.
+- Domain docs live at `docs/<domain>.md` (not in a subfolder).
+- Meta docs live under `docs/_meta/`.
+- Archive docs live under `docs/_archive/` with `status: archived` frontmatter.
+
+## Frontmatter (required)
+
+Every doc starts with:
+
+```yaml
+---
+title: Human-readable title
+domain: <matches filename stem>
+status: active | archived
+last-reviewed: YYYY-MM-DD
+verified-against:         # required only when citing schema/API/live behavior
+  - migration: <filename>
+  - mcp-query: <query summary>
+  - api-spec: <spec file>
+---
+```
+
+`verified-against:` is required only for docs citing verifiable ground truth. Pure narrative docs (architecture overviews, runbooks) can omit it.
+
+## Doc anatomy
+
+Every domain doc opens with:
+
+```markdown
+# <Title>
+
+> **What's in this doc:** <one sentence listing covered topics>.
+>
+> **What's NOT:** <topics that belong in OTHER docs, with [[wikilinks]]>.
+
+## <first major section>
+...
+```
+
+The "What's in / What's NOT" callout exists so an agent can verify it's in the right doc before reading further. Never skip it.
+
+## Cross-references
+
+- Use `[[filename]]` or `[[filename#section-anchor]]`. Filename without `.md`.
+- Filename in the link text is grep-friendly — prefer `[[business#subscription-tiers]]` over `see business doc`.
+- Never use relative paths (`../foo.md`). If a doc gets renamed, grep for the old filename finds every reference in one pass.
+
+## Code citations
+
+Every code reference includes `file:line`:
+
+```
+Step 1 — user clicks Google in `app/(auth)/sign-in/page.tsx:42`
+```
+
+Not just `app/(auth)/sign-in/page.tsx`. The line number is the difference between "I know roughly where this is" and "I can jump straight to the right line."
+
+## Verification (schema / API / live behavior)
+
+Any section citing schema, RLS policies, API shape, or live system state must:
+
+1. **Be written or refreshed by querying the source of truth.** Use whatever this project provides — DB introspection, MCP query, OpenAPI spec, GraphQL introspection, `kubectl get`, etc.
+2. **Include a section-level HTML comment recording the query used:**
+
+   ```html
+   <!-- verified-against: <query or query-summary> on YYYY-MM-DD -->
+   ```
+
+3. **Update the doc's frontmatter:** bump `last-reviewed` to today, add the relevant migration/spec to `verified-against:` if it's now load-bearing.
+
+If a section cannot be verified (tool unavailable, query ambiguous), add a `TODO verify: <what>` entry to `docs/_backlog.md` rather than guessing.
+
+## Mermaid diagrams
+
+Any flow crossing ≥2 layers (client → API → DB; middleware → auth helper → RLS) gets a mermaid sequence diagram at the top of its section. The diagram is the entry point; the prose below walks through each step with `file:line` anchors.
+
+Don't add mermaid for linear single-layer flows — prose with citations conveys the same information more compactly.
+
+## Doc size budget
+
+**Soft cap: 600 lines per domain doc.** Above that an agent loading the doc end-to-end burns context on sections irrelevant to the current task. `vault-doctor` warns when a doc exceeds the cap. Three remedies, in order of preference:
+
+1. **Extract a cheatsheet** for the highest-frequency lookup (see below). Cheaper than splitting.
+2. **Split the doc** along a real seam (e.g. `auth.md` → `auth.md` + `auth-rls.md`). Update wikilinks and `doc-ownership.yml`.
+3. **Archive stale sections** to `docs/_archive/` if the content is no longer current.
+
+Per-doc override: frontmatter `max-doc-lines: 800` (or `0` to disable).
+
+## TOC
+
+**No mandatory TOC.** Add a `## Quick map` TOC only when the doc crosses ~400 lines. Under that threshold, `##` headings + IDE outline view are sufficient.
+
+## Cheatsheets
+
+**The decision rule:** if an agent often asks a question whose answer is <50 lines but lives inside a domain doc that's >300 lines, write a cheatsheet at `docs/_cheatsheets/<topic>.md`. The agent loads the cheatsheet (small) instead of the full doc (large). That's the whole point of the layer.
+
+Concrete triggers (any one is sufficient):
+
+- A question repeatedly hits the same `<300-line> answer inside a 400+ line doc.
+- A workflow needs a lookup table the parent doc has buried in prose (e.g. RLS policy by table, role permissions, env-var → service map).
+- A pre-flight checklist for a recurring task (release, migration, incident).
+
+Each cheatsheet:
+
+- ≤50 lines total. If you can't fit it, the cheatsheet is being asked to do too much — narrow it.
+- Same frontmatter shape as a domain doc, with `domain: cheatsheet`.
+- Opens with a one-line "for full reasoning see `[[parent-doc]]`" pointer.
+- Contains a single lookup table or short list — no narrative, no reasoning.
+- Listed in `docs/_index.md` so an agent scanning the index can find it without reading the parent doc first.
+
+**Don't** create cheatsheets proactively for every doc; only after a specific lookup has proven repetitive. **Do** link each cheatsheet from its parent doc's relevant section so an agent reading the parent first can drop down to the cheatsheet on subsequent passes.
+
+## Archive, don't delete
+
+Obsolete docs move to `docs/_archive/` with `status: archived` frontmatter and a `superseded-by: [[replacement-doc-filename]]` field. Never delete — backlinks from older specs/plans stay valid.
+
+## Backlog
+
+`docs/_backlog.md` tracks known gaps:
+
+- Undocumented flows the author noticed but didn't have time to write up.
+- Sections flagged "TODO verify" because verification was skipped.
+- Code paths in `doc-ownership.yml` that have no corresponding doc section.
+
+The "update docs" workflow appends to the backlog automatically when it encounters gaps.
+
+## Touching a doc
+
+When you edit any domain doc:
+
+1. Bump `last-reviewed` to today.
+2. If you touched a verification-citing section, re-run the underlying query and update the section-level `verified-against` HTML comment.
+3. If you added a new section that maps to new code paths, add an entry to `doc-ownership.yml`.
+4. If the doc grows past ~800 lines, add a `## Quick map` TOC at the top.
+
+## Doc template
+
+The bootstrap copies a skeleton to `docs/_meta/templates/domain-doc.md`. Copy it to start a new doc:
+
+```bash
+cp docs/_meta/templates/domain-doc.md docs/<your-domain>.md
+```
+
+A separate `docs/_meta/templates/cheatsheet.md` skeleton is available for ≤50-line lookup-style references.
+
+## Anti-patterns
+
+| Don't | Do |
+|---|---|
+| Paraphrase from CLAUDE.md or older docs | Re-verify against the source of truth |
+| Cite a file without a line number | Always `file:line` |
+| Skip the "What's in / What's NOT" callout | Always include it, even on short docs |
+| Delete an obsolete doc | Move to `_archive/` with `superseded-by:` |
+| Invent content for an undocumented behavior | Stub `## TODO: <feature>` and add to `_backlog.md` |
+| Use relative paths in cross-refs | Always `[[filename]]` |

--- a/docs/chatbot.md
+++ b/docs/chatbot.md
@@ -1,0 +1,25 @@
+---
+title: Chatbot
+domain: chatbot
+status: stub
+last-reviewed: 2026-05-18
+---
+
+# Chatbot
+
+> **What's in this doc:** _(stub — will document the `/api/chat` endpoint, the system prompt content rules, and the widget JS once first edited)._
+>
+> **What's NOT:** the contact form on the same server (→ [[contact-flow]]), the deploy pipeline that runs `server.js` (→ [[deploy]]), the positioning rules the prompt content must obey (→ [[positioning]]).
+
+This doc is a placeholder. The full chatbot system has three pieces that should be documented here when first edited:
+
+1. **`/api/chat` endpoint** — Express handler at `server.js:76-105` proxying to Anthropic Claude. Rate-limited 15 req/IP/min. System prompt loaded from `prompts/chatbot-system.md` at startup with hard-fail guard (`server.js:36-47`).
+2. **System prompt content** — `prompts/chatbot-system.md`. Mirrors site copy (three tracks, pricing anchors, framing rules). The linter scans this file via `SCAN_NESTED_FILES` (see [[linter#scope-what-gets-scanned]]).
+3. **Widget JS** — `js/chatbot.js` (the floating widget, loaded on every page except `contact.html`) and `js/chatbot-demo.js` (the inline demo on `small-business.html`).
+
+When this doc is fleshed out, key topics to cover:
+- The two-surface sync hazard (pricing must match `pricing.html` exactly).
+- The 3 active linter suppressions in the prompt (they quote forbidden phrases as anti-instructions to the model).
+- The model in use (currently `claude-haiku-4-5-20251001` per `server.js:95`) and the rationale.
+- The `?v=2` cache buster on the JS file references — same pattern as [[deploy#css-cache-busting-discipline]].
+- How to update the prompt safely (lint + matches pricing + smoke test via curl).

--- a/docs/chatbot.md
+++ b/docs/chatbot.md
@@ -1,25 +1,242 @@
 ---
 title: Chatbot
 domain: chatbot
-status: stub
+status: active
 last-reviewed: 2026-05-18
+verified-against:
+  - server: server.js:36-105 (/api/chat handler + prompt loader)
+  - prompt: prompts/chatbot-system.md (full content) on 2026-05-18
+  - widget: js/chatbot.js (floating widget) on 2026-05-18
+  - widget: js/chatbot-demo.js (inline demo on small-business.html) on 2026-05-18
 ---
 
 # Chatbot
 
-> **What's in this doc:** _(stub — will document the `/api/chat` endpoint, the system prompt content rules, and the widget JS once first edited)._
+> **What's in this doc:** the `/api/chat` Express endpoint, the system prompt file and how it loads at server startup, the two front-end surfaces (floating widget + inline demo), the Claude model in use, rate limiting + session limits, the two-surface pricing-sync hazard, the markdown rendering both widgets implement, and the discipline rules for editing the prompt.
 >
-> **What's NOT:** the contact form on the same server (→ [[contact-flow]]), the deploy pipeline that runs `server.js` (→ [[deploy]]), the positioning rules the prompt content must obey (→ [[positioning]]).
+> **What's NOT:** the contact form on the same server (→ [[contact-flow]]), the deploy pipeline that runs `server.js` on Railway (→ [[deploy]]), the positioning rules the prompt content must obey (→ [[positioning]]), or the linter that polices forbidden phrases (→ [[linter]]).
 
-This doc is a placeholder. The full chatbot system has three pieces that should be documented here when first edited:
+The chatbot is the only "live AI" surface on the marketing site. It runs on the same Express server as the contact form (`server.js`, deployed to Railway), proxies to Anthropic's Claude API, and is rendered on the front-end through two distinct widgets that share the same backend.
 
-1. **`/api/chat` endpoint** — Express handler at `server.js:76-105` proxying to Anthropic Claude. Rate-limited 15 req/IP/min. System prompt loaded from `prompts/chatbot-system.md` at startup with hard-fail guard (`server.js:36-47`).
-2. **System prompt content** — `prompts/chatbot-system.md`. Mirrors site copy (three tracks, pricing anchors, framing rules). The linter scans this file via `SCAN_NESTED_FILES` (see [[linter#scope-what-gets-scanned]]).
-3. **Widget JS** — `js/chatbot.js` (the floating widget, loaded on every page except `contact.html`) and `js/chatbot-demo.js` (the inline demo on `small-business.html`).
+---
 
-When this doc is fleshed out, key topics to cover:
-- The two-surface sync hazard (pricing must match `pricing.html` exactly).
-- The 3 active linter suppressions in the prompt (they quote forbidden phrases as anti-instructions to the model).
-- The model in use (currently `claude-haiku-4-5-20251001` per `server.js:95`) and the rationale.
-- The `?v=2` cache buster on the JS file references — same pattern as [[deploy#css-cache-busting-discipline]].
-- How to update the prompt safely (lint + matches pricing + smoke test via curl).
+## Server endpoint
+
+### Startup: prompt load with hard-fail guard
+
+<!-- verified-against: server.js:36-47 on 2026-05-18 -->
+
+`server.js:36-47` reads `prompts/chatbot-system.md` at startup, trims whitespace, and refuses to start if the file is missing or empty:
+
+```javascript
+const SYSTEM_PROMPT_PATH = join(__dirname, 'prompts', 'chatbot-system.md');
+let SYSTEM_PROMPT;
+try {
+  SYSTEM_PROMPT = readFileSync(SYSTEM_PROMPT_PATH, 'utf8').trim();
+  if (!SYSTEM_PROMPT) {
+    throw new Error(`${SYSTEM_PROMPT_PATH} is empty`);
+  }
+} catch (err) {
+  console.error(`FATAL: failed to load chatbot system prompt from ${SYSTEM_PROMPT_PATH}`);
+  console.error(err.message);
+  process.exit(1);
+}
+```
+
+This is intentional — a missing prompt file is fatal. A chatbot running without its system prompt would hallucinate freely; better to crash on boot than serve junk.
+
+### `POST /api/chat`
+
+<!-- verified-against: server.js:76-105 on 2026-05-18 -->
+
+```
+POST /api/chat
+Content-Type: application/json
+Body: {
+  messages: [
+    { role: 'user' | 'assistant', content: string },
+    ...
+  ]
+}
+→ 200 { content: string }              // assistant's reply
+→ 400 { error: 'Invalid request.' }   // messages must be a non-empty array
+→ 429 { error: 'Too many requests — please wait a moment.' }
+→ 500 { error: 'Something went wrong. Please try again or email william@williamtucker.ca.' }
+```
+
+The handler (`server.js:76-105`):
+
+1. **Rate-limit check** (`server.js:78-80`) — 15 requests / IP / minute, shared with `/api/contact` via the in-memory `rateLimitMap`.
+2. **Validate** (`server.js:82-85`) — `messages` must be a non-empty array.
+3. **Sanitize + cap** (`server.js:88-91`) — filter to `user` / `assistant` roles only, keep last 12 messages, slice each `content` to 2000 chars.
+4. **Call Anthropic** (`server.js:94-99`) — `claude-haiku-4-5-20251001`, max 400 tokens, system prompt + sanitized history.
+5. **Return** the text of the first content block.
+
+### Model choice
+
+Currently `claude-haiku-4-5-20251001` per `server.js:95`. Rationale: chatbot responses are short, latency matters more than depth, and the system prompt is rigorous enough that a smaller model suffices. If responses start feeling shallow or the model starts violating the prompt rules, escalate to a Sonnet or Opus variant — but expect roughly 3–5× the latency.
+
+`max_tokens: 400` keeps replies short by design (matches the "Keep responses short" rule in the prompt). If a future change wants longer answers, bump this — but the prompt itself also constrains length so changing one without the other won't produce longer replies.
+
+---
+
+## System prompt
+
+The prompt lives at **`prompts/chatbot-system.md`** (extracted in PR #4, commit `a89a4b7`, from a previous inline location in `server.js`). The linter scans this file via `SCAN_NESTED_FILES` in `scripts/check-claims.mjs:234-235`, so credibility-drift in the prompt fails the build same as in HTML.
+
+### What the prompt does
+
+<!-- verified-against: prompts/chatbot-system.md on 2026-05-18 -->
+
+The prompt at `prompts/chatbot-system.md` is 63 lines, structured as:
+
+1. **Job statement** (line 1) — help visitors pick a track + book a call.
+2. **About William Tucker** (lines 3-5) — 12+ years, Kelowna, solo practice, AI-augmented engineer.
+3. **The three services** (lines 7-30) — Track 1 / Track 2 / Track 3 with exact pricing.
+4. **How William works** (lines 32-39) — three-step process, referral-driven local SMB focus.
+5. **Your job** (lines 41-48) — track-mapping, price-quoting discipline, redirect rules for specific projects and out-of-scope tech questions.
+6. **What you don't do** (lines 50-57) — no invented prices, no un-scoped promises, no missing-credential claims, no autonomous-AI framing, no industry speculation, no contact-info beyond the site.
+7. **Tone** (lines 59-63) — friendly, plain-spoken, confident.
+
+### Active suppression comments (3)
+
+<!-- verified-against: grep "check-claims-allow" prompts/chatbot-system.md on 2026-05-18 — 3 occurrences -->
+
+The prompt legitimately quotes forbidden phrases as anti-instructions to the model. Each one has a `<!-- check-claims-allow: ... -->` suppression with a meaningful reason:
+
+| Line | What it suppresses | Why it's legitimate |
+|---|---|---|
+| 48 | `buzzword-soup` (`revolutionary AI`, `cutting-edge`) + `credibility-theater` (`trusted by`, `as featured in`) | The rule literally tells the model NOT to use these — the prompt has to quote them to forbid them |
+| 54 | `ai-certified` (`certified AI trainer`) + `quantified-training` (`thousands of students trained`) | Same — the rule names the forbidden credentials to forbid them |
+| 55 | `ai-replaced` (the phrase "AI replaces ...") | Same — naming the framing the model must avoid |
+
+These are the textbook use case for `check-claims-allow`. See [[linter#suppression-comments]] for the broader rules.
+
+---
+
+## The two-surface pricing sync hazard
+
+**`prompts/chatbot-system.md` AND `pricing.html` both contain the canonical pricing.** They must match exactly. The linter doesn't catch numeric drift — agent discipline does.
+
+Pricing currently in lockstep (verified 2026-05-18):
+
+| Tier | Both surfaces say |
+|---|---|
+| Track 1 Discovery / Audit | $2,500 |
+| Track 1 Build | $10,000–$30,000 |
+| Track 1 Ongoing Support | $1,500/month |
+| Track 2 1:1 session | $275 per 90 min |
+| Track 2 Half-day workshop | $2,500 |
+| Track 2 Full-day workshop | $4,000 |
+| Track 2 Custom curriculum | starts at $7,500 |
+| Track 2 Training retainer | $1,250/month |
+| Track 3 Discovery | Free 30–60 min |
+| Track 3 Small Build | starting at $2,500 |
+| Track 3 Medium Build | starting at $7,500 |
+| Track 3 Maintenance | $1,000/month |
+
+**When pricing changes in `pricing.html`, the prompt MUST be updated in the same commit.** The reverse is also true. If only one surface changes, the chatbot will quote a different price than the page — exactly the kind of credibility-broker failure mode the site can't afford.
+
+The matching task is small enough that running `grep "\$" prompts/chatbot-system.md` and `grep "\$" pricing.html` before merging any pricing change is a 30-second check that prevents the drift.
+
+---
+
+## Front-end widgets
+
+Two distinct front-end widgets share the same `/api/chat` backend. Both implement their own markdown rendering and session management.
+
+### Widget 1: Floating bottom-right panel (`js/chatbot.js`)
+
+<!-- verified-against: js/chatbot.js (307 lines) on 2026-05-18 -->
+
+The default chatbot — a closed bubble in the bottom-right corner that expands into a 360 × 520 panel when clicked. Loaded on every page EXCEPT `contact.html` (which is the primary conversion surface and doesn't need a competing CTA — see [[pages#chatbot-widget-loading]]).
+
+Key implementation details from `js/chatbot.js`:
+
+| Concern | Where | Notes |
+|---|---|---|
+| API URL routing | `js/chatbot.js:6-7` | Localhost → `/api/chat`. Otherwise → `https://williamtucker-production.up.railway.app/api/chat` (the Railway-deployed server). |
+| Session limit | `js/chatbot.js:5` | `SESSION_LIMIT = 15` — after 15 user messages, the input disables and a "book a discovery call" link appears (`js/chatbot.js:231-240`). |
+| Cooldown | `js/chatbot.js:288-292` | 2-second cooldown between sends after each reply. |
+| Markdown renderer | `js/chatbot.js:157-190` | Custom inline implementation: escapes HTML, supports `**bold**`, `*italic*`, `` `code` ``, `## h2`, `### h3`, and `- bullet` lists. NOT a full markdown parser — only what the prompt is likely to emit. |
+| Greeting | `js/chatbot.js:201-203` | Hardcoded: *"Hi! I'm here to answer questions about William Tucker Solutions — services, process, or anything else. What can I help you with?"* |
+| Styling | `js/chatbot.js:9-111` | All CSS injected via `<style>` tag at runtime. Theme: Navy header + Gold accent + Page White panel. |
+
+Errors return a `wts-msg-error` red bubble (`js/chatbot.js:265-269`). Network failures fall back to *"Could not connect. Please email william@williamtucker.ca."* (`js/chatbot.js:274-279`).
+
+### Widget 2: Inline demo on small-business.html (`js/chatbot-demo.js`)
+
+<!-- verified-against: js/chatbot-demo.js (293 lines) on 2026-05-18 -->
+
+A version of the same chatbot rendered inline on `small-business.html` (in the `<div id="wts-smb-demo-root">` near the bottom of the page — see [[pages#chatbot-widget-loading]]). Same backend, different theme + smaller session budget.
+
+Differences from Widget 1:
+
+| Concern | Widget 1 (floating) | Widget 2 (inline demo) |
+|---|---|---|
+| Session limit | 15 user messages | **12 user messages** (`js/chatbot-demo.js:10`) |
+| Cooldown | 2 seconds | 1.5 seconds (`js/chatbot-demo.js:273`) |
+| Theme | Navy header + Page White panel | Dark navy panel with gold-accented bubbles (`js/chatbot-demo.js:14-125`) |
+| Open/close UI | Bubble toggle | Always-open inline | 
+| Suggestion chips | None | 4 starter prompts (`js/chatbot-demo.js:142-147`) |
+| Markdown subset | Includes headings | Lists only — no `##`/`###` heading support (`js/chatbot-demo.js:174-191`) |
+| Greeting | "Hi! I'm here to answer questions..." | *"Hi! I'm the assistant for William Tucker Solutions. Ask me about services, pricing, process, or William's background..."* (`js/chatbot-demo.js:278`) |
+
+The intent of the inline demo is *demonstration*: it shows a chatbot-on-your-site as a Track 3 Small Build use case. The dark theme + Live Chatbot tag + suggestion chips all sell the experience to a small-business visitor.
+
+---
+
+## CORS
+
+<!-- verified-against: server.js:16-29 on 2026-05-18 -->
+
+`/api/chat` is reachable from:
+- `https://williamtucker.ca`
+- `https://www.williamtucker.ca`
+- `http://localhost:3000`
+- `http://127.0.0.1:3000`
+
+Any other origin can't read the response. Both widgets respect this via the `API_URL` routing above (localhost → local server; everything else → Railway production).
+
+---
+
+## Cache-busting
+
+Both widget files are referenced from HTML with a `?v=2` query suffix — e.g., `<script src="js/chatbot.js?v=2"></script>` (every page except `contact.html` and `small-business.html`) and `<script src="js/chatbot-demo.js?v=2"></script>` (small-business.html only).
+
+Same pattern as the CSS cache-buster — see [[deploy#css-cache-busting-discipline]]. If a widget JS file changes, bump `v=2` to `v=3` across every HTML file that loads it. Currently both widgets are at `v=2` and have been for a while.
+
+---
+
+## Editing the prompt
+
+When changing `prompts/chatbot-system.md`:
+
+1. **Read [[positioning]] first.** The prompt is bound by the same framing rules as the rest of the site (12+ years, AI-accelerated never AI-replaced, RoomBooking in QA, no credentialism, no buzzword soup). Edits that violate these rules will fail the linter at build time.
+2. **Cross-check pricing against `pricing.html`** before saving. Either match it exactly or update both surfaces in the same commit.
+3. **Run `npm run check:claims`** — confirm 0 violations.
+4. **Run `npm run build`** — confirm the build still passes (the linter is the first step of build).
+5. **Smoke-test locally** if non-trivial: `npm start`, then `curl -X POST http://localhost:3000/api/chat -H "Content-Type: application/json" -d '{"messages":[{"role":"user","content":"What services do you offer?"}]}'` — confirm the response mentions all three tracks and quotes prices that match `pricing.html`.
+6. **Commit** with specific paths (not `git add -A` — see [[positioning#never-git-add--a-in-this-repo]]).
+
+---
+
+## Anti-patterns
+
+| Don't | Do |
+|---|---|
+| Quote prices in the prompt from memory | Read `pricing.html` and copy verbatim |
+| Update `pricing.html` without updating the prompt | Update both in the same commit |
+| Edit the prompt to be "more helpful" by removing the redirect rules | The redirect rules (no specific project details, no out-of-scope tech Q&A, no fabricated credentials) ARE the safety layer. Keep them. |
+| Suppress a linter violation in the prompt because "it's just an example" | If the example phrase isn't being used as an anti-instruction (with a meaningful reason), it's drift. Fix the wording instead of suppressing. |
+| Swap to a larger model thinking it'll fix bad prompt behaviour | The prompt is the contract. Fix the prompt; the model size is a different lever |
+| Add a third widget surface | Two are already a maintenance hazard. If a new surface is genuinely needed, refactor both widgets to share a common base first |
+
+---
+
+## Backlog
+
+- The two widget files duplicate ~70% of their logic (markdown renderer, session management, error handling, typing indicator). A future refactor could extract a shared `chatbot-core.js` and keep only the theme/wrapper code per surface.
+- The markdown renderer in Widget 1 supports `##` and `###` headings; the one in Widget 2 doesn't. If the prompt ever produces a `## heading`, Widget 2 will render it as a plain paragraph. Low-impact today; flag if response shape changes.
+- The session-limit "book a discovery call" link is hardcoded to `/contact.html`. If the contact-page URL ever changes (it won't, but), both widgets need updating.
+- `prefers-reduced-motion` is not currently honored in the typing-indicator bounce animation (`js/chatbot.js:88`, `js/chatbot-demo.js:82`). [[visual-system#accessibility-commitments]] commits to honoring it across the site — this is the open audit item.

--- a/docs/contact-flow.md
+++ b/docs/contact-flow.md
@@ -1,0 +1,230 @@
+---
+title: Contact Form Flow
+domain: contact-flow
+status: active
+last-reviewed: 2026-05-18
+verified-against:
+  - server: server.js:107-325 (/api/contact handler) on 2026-05-18
+  - server: server.js:70-74 (/api/contact-config) on 2026-05-18
+  - schema: Supabase `contacts` table referenced at server.js:227,237,244 — table lives in the WTSAdmin Supabase project, not in this repo
+  - email: Resend SDK at server.js:267-318
+  - spam: Cloudflare Turnstile siteverify at server.js:155-158
+---
+
+# Contact Form Flow
+
+> **What's in this doc:** the full request/response path from the `contact.html` form submit through Express to Supabase + Resend + Cloudflare Turnstile, every required env var, validation rules, the upsert-on-email behaviour, and the failure-mode design.
+>
+> **What's NOT:** the chatbot endpoint (`/api/chat` — same Express server but unrelated; see [[chatbot]] when written), the deploy pipeline that ships `server.js` (Railway, not the DreamHost rsync — see [[deploy#pipeline-overview]]), or the privacy notice copy on `privacy.html` (which is currently stale and out of step with this flow — see backlog).
+
+The contact form is the primary conversion path for cold traffic that doesn't book Calendly. PR #3 (`feat/contact-to-wtsadmin`, merged 2026-05-17) replaced the old Formspree integration with a direct write into the WTSAdmin Supabase database, an email notification to William, and an auto-reply to the lead. The whole thing runs through the `/api/contact` endpoint in `server.js`.
+
+---
+
+## Request flow
+
+```mermaid
+sequenceDiagram
+    participant U as Browser (contact.html)
+    participant CF as Cloudflare Turnstile
+    participant S as server.js (/api/contact)
+    participant T as Turnstile siteverify
+    participant DB as Supabase (WTSAdmin)
+    participant R as Resend (email)
+
+    U->>S: GET /api/contact-config → { turnstileSiteKey }
+    U->>CF: Render widget, complete challenge → token
+    U->>S: POST /api/contact { name, email, company, message, turnstileToken, _gotcha }
+    S->>S: Honeypot check (_gotcha must be empty)
+    S->>S: Validate name / email / message
+    S->>T: POST siteverify { secret, response: token, remoteip }
+    T-->>S: { success: true | false }
+    Note over S: If verification fails → 403
+    S->>S: Sanitize fields (trim + slice caps)
+    S->>DB: lookup contacts by email
+    alt existing row
+        S->>DB: update contacts.notes (append timestamped block)
+    else no row
+        S->>DB: insert new row (status: 'lead', source: 'website')
+    end
+    S->>R: send notification email to William (replyTo: lead)
+    S->>R: send auto-reply email to lead
+    S-->>U: 200 { ok: true }
+```
+
+The end-to-end happy path takes ~300–800ms depending on Turnstile latency. All three downstream services (Supabase, Turnstile, Resend) are independently failable, and the handler is written to degrade rather than fail — see "failure-mode design" below.
+
+---
+
+## Endpoints
+
+### `GET /api/contact-config`
+
+<!-- verified-against: server.js:70-74 on 2026-05-18 -->
+
+```
+GET /api/contact-config
+→ 200 { turnstileSiteKey: string | null }
+```
+
+Returns the Turnstile **site key** (public by design — it ships to the browser anyway) so the form can render the widget. The site key lives in `TURNSTILE_SITE_KEY` env var. If unset, returns `null` and the form falls back to skipping the widget (the server will also skip verification in that case — dev/staging fallback).
+
+The **secret key** (`TURNSTILE_SECRET_KEY`) is never exposed by this endpoint. It stays server-only.
+
+### `POST /api/contact`
+
+<!-- verified-against: server.js:167-325 on 2026-05-18 -->
+
+```
+POST /api/contact
+Content-Type: application/json
+Body: {
+  name: string,                  // 2–200 chars after trim
+  email: string,                 // RFC-ish via /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+  company?: string,              // optional, max 200 chars
+  service_interest?: string,     // optional, max 100 chars (free-text track hint)
+  message: string,               // 5–5000 chars after trim
+  turnstileToken?: string,       // required in prod; skipped if no TURNSTILE_SECRET_KEY
+  _gotcha?: string               // honeypot — must be empty/unset
+}
+→ 200 { ok: true }              // happy path (also returned silently when honeypot triggered)
+→ 400 { error: '...' }           // validation failure (clear message for user)
+→ 403 { error: 'Spam check failed...' }
+→ 429 { error: 'Too many requests — please wait a moment.' }
+```
+
+Rate-limited 15 requests per IP per minute (shared limiter with `/api/chat` — see `server.js:49-59`).
+
+---
+
+## Validation rules
+
+<!-- verified-against: server.js:188-204 on 2026-05-18 -->
+
+| Field | Rule | Error if violated |
+|---|---|---|
+| `name` | string, ≥2 chars after trim | "Please enter your name." |
+| `email` | matches `/^[^\s@]+@[^\s@]+\.[^\s@]+$/` | "Please enter a valid email address." |
+| `message` | string, ≥5 chars after trim | "Please include a brief message." |
+| `_gotcha` | must be empty/unset | _(silent — returns 200 to dissuade bot retries)_ |
+| Turnstile | `turnstileToken` verifies via siteverify, OR `TURNSTILE_SECRET_KEY` not set (dev fallback) | "Spam check failed. Please refresh the page and try again." (HTTP 403) |
+
+After validation, fields are sanitized (`server.js:207-212`):
+
+- `name` → trim + slice(0, 200)
+- `email` → trim + lowercase + slice(0, 200)
+- `company` → trim + slice(0, 200), or `null` if empty
+- `message` → trim + slice(0, 5000)
+- `service_interest` → trim + slice(0, 100), or `null` if empty
+
+---
+
+## Supabase write — upsert on email
+
+<!-- verified-against: server.js:222-263 on 2026-05-18 — Supabase JS client v2 using service-role key -->
+
+The handler upserts into the **WTSAdmin** Supabase project's `contacts` table (NOT a WTS-marketing-site DB — this site has no DB of its own; it writes directly into the admin app's data store).
+
+| Field | Source | Notes |
+|---|---|---|
+| `name` | form `name` | |
+| `email` | form `email` | unique lookup key |
+| `company` | form `company` or `null` | |
+| `source` | `'website'` | hard-coded for this endpoint |
+| `status` | `'lead'` | initial state — WTSAdmin manages transitions |
+| `notes` | timestamped block (date, service_interest if any, message) | appended on subsequent submissions |
+
+The lookup-then-write logic (`server.js:226-258`):
+
+1. Query `contacts` for a row with `email = cleanEmail`.
+2. If a row exists → append the new note block to existing `notes` (newline-separated).
+3. If no row exists → insert a new row.
+
+The newly-created or existing row's `id` (a UUID) is captured into `contactId` for inclusion in the notification email's deep link.
+
+**Note:** the actual `contacts` table schema is defined and migrated in the WTSAdmin repo, not here. This server uses the Supabase service-role key (`WTSADMIN_SUPABASE_SERVICE_KEY`) which bypasses RLS. See WTSAdmin repo for table definition and column constraints.
+
+### Failure mode
+
+If the Supabase write fails (env var missing, network error, table missing), the handler **does not return an error to the user** (`server.js:259-263`). It logs the error to the server console (`[contact] Supabase write failed: <message>`) and continues to the email send. The rationale: if the DB is down, the email is the backup record — William can manually catch up the contact later from the notification email.
+
+---
+
+## Email — notification + auto-reply
+
+<!-- verified-against: server.js:265-322 on 2026-05-18 — Resend SDK -->
+
+Two emails sent for every successful submission, both via Resend:
+
+### Notification (to William)
+
+| Field | Value |
+|---|---|
+| `from` | `RESEND_FROM_EMAIL` env (default `noreply@williamtucker.ca`) wrapped as `William Tucker Solutions <{email}>` |
+| `to` | `WTSADMIN_NOTIFY_EMAIL` env (default `william@williamtucker.ca`) |
+| `replyTo` | The lead's email (so William can hit Reply and respond directly) |
+| `subject` | `New website enquiry from {name}` + optional service-interest suffix |
+| body | Plain text: lead's name, email, company, service interest, message, plus a deep link to the contact in admin (or a note if Supabase write failed) |
+
+### Auto-reply (to lead)
+
+| Field | Value |
+|---|---|
+| `from` | Same as notification |
+| `to` | The lead's email |
+| `subject` | `Got your message — I'll reply within 1 business day` |
+| body | First-name greeting, confirmation, fallback email address, signature |
+
+Both emails are best-effort: if Resend errors, the handler logs and continues. The lead is already in Supabase at that point so the data isn't lost.
+
+---
+
+## Required environment variables
+
+<!-- verified-against: server.js env reads + .env.example (if present) on 2026-05-18 -->
+
+Set these on Railway (the server's deploy target — NOT in DreamHost or anywhere the static site is served).
+
+| Var | Purpose | Behavior if missing |
+|---|---|---|
+| `ANTHROPIC_API_KEY` | `/api/chat` only | Chatbot returns 500; doesn't affect contact form |
+| `WTSADMIN_SUPABASE_URL` | Supabase project URL for WTSAdmin DB | DB write fails (handler logs + continues) |
+| `WTSADMIN_SUPABASE_SERVICE_KEY` | Service-role key for the same project | Same as above |
+| `WTSADMIN_NOTIFY_EMAIL` | Inbox for the notification email | Falls back to `william@williamtucker.ca` |
+| `RESEND_API_KEY` | Resend SDK auth | Emails fail to send (handler logs + continues) |
+| `RESEND_FROM_EMAIL` | Sender address for both emails | Falls back to `noreply@williamtucker.ca` |
+| `TURNSTILE_SITE_KEY` | Public Cloudflare Turnstile site key (returned to browser via `/api/contact-config`) | Form skips widget rendering; server skips verification (dev fallback) |
+| `TURNSTILE_SECRET_KEY` | Secret used to call siteverify | Server skips verification with a `console.warn` (dev fallback only) |
+| `PORT` | Server bind port | Falls back to `3000` |
+
+Production deploys MUST set `TURNSTILE_SECRET_KEY` — without it, the contact form is unprotected against bot spam.
+
+The `.env.example` file at the repo root lists these (verify on next edit). Local dev: copy `.env.example` to `.env`, fill in dev values, and the server reads it via `dotenv.config()`.
+
+---
+
+## Anti-spam layers (in firing order)
+
+1. **Honeypot field `_gotcha`** (`server.js:185`) — invisible to humans, filled by naive bots. Returns 200 silently so the bot doesn't retry.
+2. **Validation** (`server.js:188-196`) — too-short name / invalid email / too-short message rejected with 400.
+3. **Cloudflare Turnstile** (`server.js:199-204`) — the actual challenge. Frictionless for humans, blocks scripted submissions.
+4. **Rate limit** (`server.js:169-171`) — 15 requests / IP / minute. Shared with `/api/chat`.
+
+If any of layers 2–4 fail, the lead never reaches Supabase or Resend.
+
+---
+
+## Frontend contract
+
+The form on `contact.html:165-215` POSTs to `/api/contact` with the JSON body shape documented above. The Turnstile widget is rendered using the public site key fetched from `/api/contact-config`. The script that wires this up lives in the inline `<script>` block at the bottom of `contact.html` (verify on next edit — JS file path may vary).
+
+CORS allows the static site origin (`williamtucker.ca`, `www.williamtucker.ca`, plus `localhost:3000` for dev) via the middleware in `server.js:16-29`. Any other origin can't read the response.
+
+---
+
+## Backlog
+
+- **`privacy.html` references Formspree + Calendly.** Both are wrong as of PR #3. Privacy notice must be rewritten to name **Supabase** (DB), **Resend** (email), **Cloudflare Turnstile** (spam), and **Railway** (server hosting). See PIPEDA accuracy requirements.
+- **The Supabase service-role key bypasses RLS.** If the WTSAdmin team adds RLS to the `contacts` table that should apply to this insert path, this server's write will fail. Coordinate with WTSAdmin owner before tightening RLS.
+- **No dedupe on rapid resubmits.** A user double-clicking submit will create two `notes` entries on the same contact. Not a real issue at current scale; flag if it shows up in admin.
+- **No retry logic on Resend failures.** A transient Resend outage drops the email silently (logged only). Could add a simple exponential-backoff retry, but the DB write covers data preservation so it hasn't been a priority.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,0 +1,215 @@
+---
+title: Deployment & Caching
+domain: deploy
+status: active
+last-reviewed: 2026-05-18
+verified-against:
+  - workflow: .github/workflows/deploy.yml
+  - package-json: package.json scripts block
+  - live-headers: curl -sI https://williamtucker.ca/ on 2026-05-18
+---
+
+# Deployment & Caching
+
+> **What's in this doc:** how a push to `master` becomes a live deploy at williamtucker.ca — the GitHub Actions workflow, the rsync to DreamHost, the Cloudflare CDN layer, browser caching behaviour, the CSS cache-busting discipline that every CSS-affecting commit must follow, and the chatbot proxy hosted separately on Railway.
+>
+> **What's NOT:** the contact-form endpoint env config (→ [[contact-flow]]), the build-time linter that gates deploys (→ [[linter]]), or the marketing-site CDN cache rules for individual assets (everything's served with `max-age=600` — no per-asset overrides).
+
+The deploy pipeline is intentionally simple — three independently-cached layers (origin → Cloudflare → browser), one rsync, one GitHub Action. Most caching failures show up at the browser layer; understanding the layer ordering is what makes them debuggable.
+
+---
+
+## Pipeline overview
+
+```mermaid
+sequenceDiagram
+    participant Dev as Local
+    participant GH as GitHub
+    participant Act as Actions runner
+    participant DH as DreamHost
+    participant CF as Cloudflare
+    participant U as User's browser
+
+    Dev->>GH: git push (PR or master)
+    GH->>Act: trigger deploy.yml
+    Act->>Act: lint job (npm run check:claims)
+    Note over Act: lint fails → no deploy
+    Act->>DH: rsync site files via SSH
+    U->>CF: request williamtucker.ca/page.html
+    CF->>DH: origin fetch (if not edge-cached)
+    DH-->>CF: HTML + Cache-Control: max-age=600
+    CF-->>U: HTML (DYNAMIC or HIT)
+    U->>U: store CSS/HTML in browser cache for 600s
+```
+
+Three independent caches sit between a deploy and what the user actually sees:
+
+1. **DreamHost origin** — updated synchronously by the rsync step. Refreshes on every successful master push.
+2. **Cloudflare edge** — sits in front of the origin. Header `cf-cache-status` indicates whether the response came from edge (`HIT`/`MISS`) or passed through (`DYNAMIC`). At time of writing, HTML responses report `DYNAMIC` — verified 2026-05-18 via `curl -sI https://williamtucker.ca/contact.html`.
+3. **Browser cache** — the trickiest layer. `Cache-Control: max-age=600` (set by DreamHost) means every modern browser holds the response for up to 10 minutes regardless of subsequent server-side changes. iPhone Safari "private browsing" does NOT bypass this fully — incognito tabs opened during a cache window may reuse the cached resource.
+
+The 2026-05-17 incident that drove this doc's creation was a missed CSS layer at level 3: the HTML referenced `css/styles.css` (no version), so even when a new HTML deployed and the user fetched it fresh, the browser reused the cached CSS from the previous deploy. The cache-busting discipline below exists to prevent that.
+
+---
+
+## GitHub Actions workflow
+
+<!-- verified-against: `.github/workflows/deploy.yml` on 2026-05-18 -->
+
+Source: `.github/workflows/deploy.yml`.
+
+Two jobs run on every push to `master` and on every PR targeting `master`:
+
+| Job | When it runs | Purpose | Cite |
+|---|---|---|---|
+| `lint` | Every push + every PR | Runs `npm run check:claims` (the credibility linter). Failure blocks deploy. | `.github/workflows/deploy.yml:10-21` |
+| `deploy` | Only on push to master (gated by `needs: lint`) | SSH key setup + rsync to DreamHost | `.github/workflows/deploy.yml:23-56` |
+
+The rsync command excludes a lot — anything not part of the public site does not ship:
+
+```
+rsync -avz --delete \
+  --exclude='.git' --exclude='.github' \
+  --exclude='tailwind.config.js' --exclude='src' \
+  --exclude='docs' --exclude='tests' --exclude='scripts' \
+  --exclude='.env' --exclude='node_modules' \
+  --exclude='server.js' \
+  --exclude='package.json' --exclude='package-lock.json' \
+  --exclude='CLAUDE.md' \
+  -e "ssh -i ~/.ssh/deploy_key" \
+  ./ dh_xjct9a@pdx1-shared-a4-03.dreamhost.com:/home/dh_xjct9a/williamtucker.ca/
+```
+
+What this means in practice:
+- `server.js` is **not** deployed by this pipeline. The Express server runs on Railway, deployed separately when `master` changes there (see Railway dashboard).
+- `--delete` means files removed from the repo are removed from DreamHost on the next deploy. PR #6 accidentally committed 134 local-tooling files; PR #7 removed them; the deploy after PR #7 wiped them off DreamHost. **This is the reason `git add -A` is dangerous in this repo** — see [[positioning#never-git-add--a-in-this-repo]].
+
+Secrets:
+- `secrets.DREAMHOST_SSH_KEY_LAPTOP` — the private SSH key authorized for `dh_xjct9a@pdx1-shared-a4-03.dreamhost.com`. Configured in GitHub repo settings → Actions → Secrets.
+
+---
+
+## CSS cache-busting discipline
+
+**This is the most important section in this doc. Failing to follow it makes deploys appear broken to users.**
+
+`css/styles.css` is referenced from every HTML page. Without a version query string on the href, browsers will reuse the cached CSS even after a fresh deploy, leaving new HTML classes with no CSS rules to bind to.
+
+### The rule
+
+Every HTML file's stylesheet link looks like this — `contact.html:19`:
+
+```html
+<link rel="stylesheet" href="css/styles.css?v=20260517b" />
+```
+
+The `?v=YYYYMMDDx` query string is the cache-buster. **Every commit that adds new Tailwind utility classes (or otherwise changes CSS output) MUST bump the version in lockstep, across all 8 HTML pages.**
+
+Naming convention: `?v=YYYYMMDD<letter>` where `<letter>` increments through the day. First deploy on 2026-05-17 → `?v=20260517a`. Second → `?v=20260517b`. Next day starts fresh at `?v=20260518a`.
+
+### Why this is required
+
+Tailwind generates utilities lazily — only classes that appear in source files end up in `css/styles.css`. If a PR adds `class="order-1 md:order-2"` to an HTML element, the `.order-1` and `.md\:order-1` rules are NEW in CSS. Browsers serving the old cached CSS won't have those rules. The new HTML class is a no-op.
+
+### How to bump correctly
+
+When you ship any change that modifies CSS:
+
+1. Pick the next version letter (check the current value in any HTML file).
+2. Use `sed` to update all 8 HTML files in one pass:
+   ```bash
+   for f in *.html; do
+     sed -i 's|css/styles.css?v=YYYYMMDDold|css/styles.css?v=YYYYMMDDnew|' "$f"
+   done
+   ```
+3. Verify with `grep -c "css/styles.css?v=YYYYMMDDnew" *.html` — expect `8`.
+4. Run `npm run build` to recompile `css/styles.css` so the new utilities are present.
+5. Commit both `*.html` and `css/styles.css` together.
+
+The 2026-05-17 incident's worst sub-failure was PR #8 only bumping `contact.html` (the file being edited) and leaving 7 pages on the previous `?v=`. Those 7 pages continued serving stale CSS to returning visitors until natural expiration. The current vault state has all 8 pages on `?v=20260517b` — **verify with the grep above before any new bump**.
+
+### What does NOT need a bump
+
+- Pure copy edits (HTML text changes that use existing utility classes already in the CSS)
+- Image swaps
+- JS-only changes
+- `prompts/chatbot-system.md` edits (server-side)
+
+If you're unsure whether your change touched CSS: run `npm run build`, then `git diff css/styles.css`. If the diff is non-empty (beyond whitespace), bump the cache-buster.
+
+---
+
+## Build command
+
+<!-- verified-against: `package.json` scripts on 2026-05-18 -->
+
+From `package.json:9`:
+
+```
+"build": "npm run check:claims && npx @tailwindcss/cli -i src/input.css -o css/styles.css --minify"
+```
+
+Two phases:
+1. **Lint gate.** `npm run check:claims` — if any forbidden-phrase pattern fires, the build exits non-zero and the deploy never runs. See [[linter]].
+2. **Tailwind compile.** Reads `src/input.css`, scans the repo for utility classes, writes minified `css/styles.css`.
+
+The GitHub Actions deploy job does NOT run `npm run build` — it only runs `npm run check:claims` and then rsyncs the existing `css/styles.css` from the commit. **This means you must commit a freshly-built `css/styles.css` whenever your HTML changes the set of utilities in use.** A future improvement (not yet implemented) would be to run `npm run build` in CI and commit the resulting CSS, but currently the build is a manual local step.
+
+---
+
+## Cloudflare layer
+
+Cloudflare DNS proxies williamtucker.ca. Response headers always include:
+
+```
+Server: cloudflare
+Cache-Control: max-age=600
+cf-cache-status: DYNAMIC
+```
+
+`DYNAMIC` means Cloudflare didn't cache this response — every request goes through to DreamHost origin. So Cloudflare is currently a DNS + DDoS layer here, not an aggressive cache.
+
+If `cf-cache-status` ever changes to `HIT`, edge purging may become necessary on deploys. Today it isn't.
+
+To verify what's actually being served to a user agent:
+
+```bash
+curl -sI https://williamtucker.ca/contact.html
+curl -s -A "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15" https://williamtucker.ca/contact.html | grep order-
+```
+
+When debugging "user says it didn't update", check headers FIRST — `last-modified`, `cf-cache-status`, `Cache-Control` — before suspecting the deploy.
+
+---
+
+## Debugging cache problems (the 2026-05-17 playbook)
+
+If a user reports "I deployed but my phone still shows the old page", work the layers in order:
+
+| Layer | What to check | How |
+|---|---|---|
+| 1. Git | Did the commit land on master? | `git log master --oneline -5` |
+| 2. Deploy | Did the GitHub Actions run succeed? | `gh run list --branch master --limit 1` |
+| 3. Origin | Does the file on DreamHost have the change? | `curl -s https://williamtucker.ca/path | grep <expected-marker>` |
+| 4. Cloudflare | Is anything edge-cached? | `curl -sI <url>` — look at `cf-cache-status` |
+| 5. CSS link | Did the cache-buster bump in the HTML? | `curl -s <html-url> | grep styles.css` |
+| 6. CSS content | Does the bumped CSS file have the new utilities? | `curl -s <css-url> | grep <new-class>` |
+| 7. User browser | Force fresh fetch with a unique URL | Append `?nocache=$(date +%s)` to test |
+
+The 2026-05-17 incident failed at layer 5 — origin had the change, browser ignored it.
+
+---
+
+## What's intentionally NOT here
+
+- **No staging environment.** DreamHost has one slot, which is production. There is no `preview.williamtucker.ca` or equivalent. Local `npm start` is the only pre-prod check. See [[positioning#deploy-discipline-do-not-bypass]] for the matching "never merge without local-test approval" rule.
+- **No Vercel preview deploys.** The site is not a Vercel project. WTSAdmin (a different repo, `D:\code\wtsadmin`) is on Vercel; do not confuse them.
+- **No automated build-in-CI for Tailwind.** Local `npm run build` writes `css/styles.css` and you commit it. Drift between source `*.html` classes and committed `css/styles.css` is silent until you check.
+
+---
+
+## Backlog
+
+- The CI ought to run `npm run build` and verify the committed `css/styles.css` matches what would be regenerated. If they diverge, the build should fail. (Not implemented.)
+- A pre-commit hook that auto-bumps the cache-buster when `css/styles.css` changes would prevent the "I forgot to bump" failure mode. (Not implemented.)
+- The deploy currently has no rollback story. If a bad master push goes live, the recovery path is "revert + push + wait for next deploy run". A pinned-tag rollback workflow would be cheap to add.

--- a/docs/linter.md
+++ b/docs/linter.md
@@ -1,0 +1,202 @@
+---
+title: Claim Linter
+domain: linter
+status: active
+last-reviewed: 2026-05-18
+verified-against:
+  - script: scripts/check-claims.mjs (15 patterns at time of audit)
+  - tests: tests/check-claims.test.mjs (47 tests pass)
+---
+
+# Claim Linter
+
+> **What's in this doc:** what the `check-claims` linter does, how it's wired into the build, the pattern catalog, how to add a new pattern, suppression-comment syntax, scope rules (what gets scanned), and the failure-mode it's designed to prevent.
+>
+> **What's NOT:** deploy mechanics (→ [[deploy]]), the framing rules the linter enforces in plain language (→ [[positioning]]).
+
+The linter exists to prevent credibility drift on copy. Four of the five commits immediately before its creation were "credibility sweeps" — agents had inflated William's experience or compressed project timelines while editing, and a human had to revert. The linter catches these regressions automatically before they ship.
+
+---
+
+## How it runs
+
+<!-- verified-against: package.json scripts on 2026-05-18 -->
+
+Two entry points, defined in `package.json:7-9`:
+
+| Command | What it does | When it runs |
+|---|---|---|
+| `npm run check:claims` | Scans copy files for forbidden phrase patterns | Standalone; also as the first step of `npm run build`; also in the GitHub Actions `lint` job on every PR and master push |
+| `npm run test:claims` | Runs `tests/check-claims.test.mjs` against the linter itself | Standalone; not in CI — tests are for local validation when adding patterns |
+
+A non-zero exit from `check:claims` fails the build and (in CI) blocks the deploy. Treat the linter as a hard gate.
+
+---
+
+## Scope: what gets scanned
+
+<!-- verified-against: scripts/check-claims.mjs:222-235 on 2026-05-18 -->
+
+The walker in `scripts/check-claims.mjs:241-272` enumerates files using two rules:
+
+**Top-level files** (`SCAN_TOP_LEVEL_FILES`, `scripts/check-claims.mjs:229-232`):
+- `server.js`
+- `PRODUCT.md`
+- Any `*.html` file at the repo root that does NOT start with an underscore
+
+**Nested files** (`SCAN_NESTED_FILES`, `scripts/check-claims.mjs:234-235`):
+- `prompts/*.md` (so `prompts/chatbot-system.md` is scanned)
+
+**Skipped directories** (`SKIP_DIRS`, `scripts/check-claims.mjs:222-225`):
+`node_modules`, `.git`, `.claude`, `.agents`, `.superpowers`, `.worktrees`, `css`, `js`, `img`, `dist`, `.next`.
+
+**Skipped path fragments** (`SKIP_PATH_FRAGMENTS`, `scripts/check-claims.mjs:227`):
+`docs/superpowers/` — historical specs and plans aren't policed.
+
+**Important:** vault docs under `docs/` are NOT currently scanned. If a vault doc starts citing forbidden phrases (e.g., "trained thousands of students" appearing in `positioning.md`), the linter won't catch it. This is a known scope gap — see [[_backlog]] if it becomes a problem.
+
+A typical run scans 11 files (8 HTML + `server.js` + `PRODUCT.md` + `prompts/chatbot-system.md`). Output:
+
+```
+check-claims: scanned 11 files, 0 violations.
+```
+
+---
+
+## Pattern catalog
+
+<!-- verified-against: scripts/check-claims.mjs PATTERNS array on 2026-05-18 (15 patterns) -->
+
+Patterns live in `scripts/check-claims.mjs:9-110` as a single `PATTERNS` array. Each pattern has an `id`, a `type` (`line` or `proximity`), and a `reason` string included in violation output.
+
+### Line patterns
+
+Run line-by-line. A regex match anywhere on a line fires the violation.
+
+| `id` | What it catches | Why |
+|---|---|---|
+| `years-inflated` | `13+` through `19+` years | PROFILE.md §10: 12+ years since 2013. |
+| `name-bill` | `Bill` as a standalone word | Workspace CLAUDE.md: address user as Will/William, never Bill. |
+| `ai-replaced` | `AI replaces / replaced` | PROFILE.md §10: AI-accelerated, never AI-replaced. |
+| `ai-automation` | `AI automation` as a phrase (NOT `AI Workflow Automation` — `workflow` breaks the regex) | PROFILE.md §10: augmented senior engineering, not automation. **This is why Track 3's anchor is `#ai-workflow-automation`, not `#ai-automation`** — see [[pages#anchor-naming]] for the full discussion. |
+| `legacy-certs` | `HackerRank`, `TestDome` | Removed in earlier credibility sweep — do not reintroduce. |
+| `ai-replaces-engineers` | `fully autonomous AI`, `no human in the loop`, `AI replaces developers/engineers` | Three-track reframe failure mode. |
+| `ai-certified` | `certified AI trainer / consultant / practitioner`, `AI-certified` | William has no AI certifications. |
+| `quantified-training` | `thousands of students/trainees/people`, `trained 10+/50+/100+ teams` | Training-track quantified claims aren't backed. |
+| `buzzword-soup` | `industry-leading AI`, `cutting-edge technology`, `revolutionary AI/approach/platform` | Referral-driven plain voice; buzzwords are off-tone. |
+| `credibility-theater` | `trusted by`, `as featured in`, `as seen in` | Site is referral-driven, not authority-led. |
+
+### Proximity patterns
+
+Match when two regexes both fire within a character window. Used for compound claims that need both halves to be wrong together.
+
+| `id` | Primary regex | Near regex | Window | Why |
+|---|---|---|---|---|
+| `room-booking-prod` | `Room Booking` | `in production`, `production[-\s]?ready`, `live in production` | 240 chars | RoomBooking is in QA, not production. |
+| `bis-compressed` | `BIS / Facilities Information System / Facilities Info` | `1 day / 2 days / etc.` | 240 chars | BIS was ~7 weeks, 66 commits, 14 branches. |
+| `mysql-prod` | `MySQL` | `production` | 160 chars | No production MySQL experience. |
+| `aws-prod` | `AWS` | `production` | 160 chars | No AWS experience. |
+| `salesforce-prod` | `Salesforce` | `production` | 160 chars | No Salesforce experience. |
+
+### Output format
+
+A violation looks like (from `scripts/check-claims.mjs:309-320`):
+
+```
+check-claims: 1 violations found.
+
+  contact.html:42  [name-bill]
+    matched: Bill
+    reason : Workspace CLAUDE.md: address the user as "Will" or "William," never "Bill."
+```
+
+---
+
+## Adding a new pattern
+
+When you notice a new failure mode (e.g., agents keep writing some forbidden phrase you didn't anticipate), add a pattern.
+
+1. **Write the failing test first.** In `tests/check-claims.test.mjs`, append a block like:
+   ```javascript
+   const myPattern = PATTERNS.find(p => p.id === 'my-new-pattern');
+
+   test('my-new-pattern flags the bad phrase', () => {
+     assert.ok(myPattern, 'pattern not found in catalog');
+     assert.ok(checkLine('Some text with the bad phrase here', 1, myPattern));
+   });
+
+   test('my-new-pattern does not flag legitimate copy', () => {
+     assert.equal(checkLine('A clean sentence.', 1, myPattern), null);
+   });
+   ```
+2. **Run `npm run test:claims` and watch it fail** with `pattern not found in catalog`. This confirms the test is actually checking the pattern existence.
+3. **Add the pattern to the `PATTERNS` array** in `scripts/check-claims.mjs`. Match the existing style:
+   ```javascript
+   {
+     id: 'my-new-pattern',
+     type: 'line',
+     rule: /\b(bad\s+phrase|other\s+bad\s+phrase)\b/i,
+     reason: 'Why this is forbidden — cite the source-of-truth doc or memory.',
+   },
+   ```
+4. **Run `npm run test:claims`** — all tests should now pass.
+5. **Run `npm run check:claims`** against current content — must report `0 violations`. If it fires on real existing content, that means there's real drift to fix; DO NOT soften the pattern to make the violation disappear.
+6. **Commit pattern + tests together** in one commit with a `feat(linter):` prefix.
+
+The current 47-test suite (15 patterns × ~3 tests each on average + structural tests) is the floor. Don't ship a pattern without tests.
+
+---
+
+## Suppression comments
+
+<!-- verified-against: scripts/check-claims.mjs:207-220 (SUPPRESS_RE) on 2026-05-18 -->
+
+Sometimes a forbidden phrase appears legitimately — for example, a "What you don't do" rule that quotes the phrase to forbid it. The suppression mechanism is the escape valve.
+
+### Syntax
+
+The regex is `/(?:<!--|\/\/)\s*check-claims-allow:\s*([^>\n]+?)\s*(?:-->|$)/` — `scripts/check-claims.mjs:207`.
+
+Two forms work:
+
+```html
+<!-- check-claims-allow: explain why this is OK in 10+ chars -->
+```
+
+```javascript
+// check-claims-allow: explain why this is OK in 10+ chars
+```
+
+The reason text MUST be at least 10 characters (`MIN_REASON_LEN`, `scripts/check-claims.mjs:208`). Shorter reasons are rejected — the comment is treated as if it weren't there, and the violation fires.
+
+### Placement
+
+- For **line patterns**: the suppression comment must be on the SAME line as the matched text (`scripts/check-claims.mjs:288`).
+- For **proximity patterns**: the suppression must be on the line of the PRIMARY match (`scripts/check-claims.mjs:298-299`). If the suppression is only on the near-match line, the violation still fires.
+
+### When suppression is appropriate
+
+✅ Quoting forbidden phrases to forbid them in agent-facing rules (`prompts/chatbot-system.md` does this 3 times).
+✅ FAQ questions that themselves quote the forbidden phrase rhetorically (`faq.html:142` — "Are you a certified AI trainer?" with answer "No.").
+✅ Inline doc comments in `PRODUCT.md` listing honest stack gaps (the rule itself names the forbidden word).
+
+❌ Silencing a real claim that turns out to need fixing. If the linter fires on real copy and the suppression is being used to ship a credibility sweep, **stop**. Either fix the copy or refuse to ship.
+
+The 6 active suppressions in this repo (as of 2026-05-18): 3 in `prompts/chatbot-system.md`, 3 in `PRODUCT.md`, 1 in `faq.html`. All legitimate.
+
+---
+
+## Build integration
+
+`npm run build` runs `npm run check:claims` FIRST (`package.json:9`). If the linter fails, Tailwind never compiles and the CSS file isn't regenerated. This means a broken-copy commit can't accidentally ship just because the build technically succeeded.
+
+The GitHub Actions deploy workflow runs `npm run check:claims` as a separate lint job (`.github/workflows/deploy.yml:10-21`) on every PR and master push. Failed lint = no deploy. See [[deploy#github-actions-workflow]].
+
+---
+
+## Anti-patterns
+
+- **Weakening a pattern to silence a real violation.** The pattern is the canary. If it fires on real content, the content is wrong, not the pattern.
+- **Adding suppressions without a meaningful reason.** Reasons under 10 chars are rejected; reasons like "needed" or "fine here" pass the length check but defeat the audit-trail purpose. Write a sentence explaining why this specific occurrence is legitimate.
+- **Adding a pattern without a test.** Tests are how we know the pattern catches what it's supposed to and doesn't false-positive on adjacent legitimate content. Skipping them is how patterns rot.
+- **Scoping the scanner more broadly without thinking about cost.** Adding all `docs/**/*.md` to scope would catch vault drift but would also re-scan ~5 large doc files on every build. If you go there, also add an HTML-comment-aware skip for the "What's in / What's NOT" examples that may quote forbidden phrases as anti-references.

--- a/docs/pages.md
+++ b/docs/pages.md
@@ -1,0 +1,211 @@
+---
+title: HTML Pages
+domain: pages
+status: active
+last-reviewed: 2026-05-18
+verified-against:
+  - source: 8 HTML files at repo root on 2026-05-18
+  - anchors: grep "id=" services.html / pricing.html
+---
+
+# HTML Pages
+
+> **What's in this doc:** the 8 public HTML pages, what each one does, the anchor-naming convention that interacts with the linter, the breakpoint discipline for mobile-vs-desktop work, nav consistency rules, and where the chatbot widget loads.
+>
+> **What's NOT:** copy content / positioning (→ [[positioning]]), the contact form's server-side behaviour (→ [[contact-flow]]), the design tokens that style these pages (→ [[visual-system]]), cache-busting for the stylesheet (→ [[deploy#css-cache-busting-discipline]]).
+
+The site is a flat collection of 8 hand-authored HTML pages, no framework, no router. Each page repeats the header, nav, and footer markup — so cross-page consistency is a maintenance discipline, not an enforced contract.
+
+---
+
+## Page inventory
+
+<!-- verified-against: ls *.html in repo root on 2026-05-18 -->
+
+| File | Role | Notable structural feature |
+|---|---|---|
+| `index.html` | Home — hero + three-track preview + stat strip + small-business CTA + lead-magnet section | Two CTA buttons in hero (`Book a Free Discovery Call` + `See the Three Tracks →`) |
+| `services.html` | Three tracks long-form — each track has a labelled section with cards | Hero has anchor-button row jumping to the three section IDs |
+| `pricing.html` | Three pricing sections matching the three tracks; free discovery-call banner at top | Pricing-card heading anchors don't link cross-page; mobile shows a 4-up grid that collapses to 2×2 then 1-col |
+| `small-business.html` | Kelowna SMB landing — pain-card grid, before/after section, Quick Win package, three-track preview, interactive quiz, chatbot demo | Inline `<style>` block (lines 20–43) for `.pain-card` hover/reveal — the ONLY page-specific stylesheet on the site |
+| `about.html` | Bio, expertise grid, education, independent projects, philosophy | Heaviest individual page in raw vertical height — long scroll |
+| `faq.html` | 18 Q&As across 5 groups, wrapped in `<details>`/`<summary>` accordions | Each Q&A is a `<details class="group ...">` with a `group-open:rotate-180` chevron span |
+| `contact.html` | "Let's Talk" hero + "How This Works" / "Send a Message" two-column layout + "Other Ways to Reach Me" | Form POSTs to `/api/contact` — see [[contact-flow]]. NO chatbot widget loads here. |
+| `privacy.html` | Privacy notice | PIPEDA — must accurately name third-party processors. See known-drift backlog if this is stale. |
+
+The site has **no** `case-studies.html` (deleted in PR #4) or `checklist.html` (deleted in PR #4). The page-routing memory `project-site-no-work-samples` codifies the "no portfolio on the public site" decision — see that memory before reintroducing.
+
+---
+
+## Anchor naming
+
+The `ai-workflow-automation` choice (and the linter collision it dodges):
+
+<!-- verified-against: services.html:102,173,238 and pricing.html section IDs on 2026-05-18 -->
+
+The three service tracks have specific section anchors used by hero CTAs, pricing-page-internal links, index.html services-preview, and small-business.html three-track preview:
+
+| Track | Section ID on `services.html` | Section ID on `pricing.html` | Why the name |
+|---|---|---|---|
+| 1 — Software Development | `#ai-development` | `#ai-development-pricing` | Short, mobile-first; doesn't collide with anything |
+| 2 — Training | `#ai-training` | `#ai-training-pricing` | Same |
+| 3 — Workflow Automation | **`#ai-workflow-automation`** | **`#ai-workflow-automation-pricing`** | **MUST include `-workflow-`** — see below |
+
+**Why Track 3 is `ai-workflow-automation` and NOT `ai-automation`:** The claim linter's `ai-automation` pattern (`scripts/check-claims.mjs:28-32`) catches the phrase "AI automation" as a violation of the AI-accelerated framing rule. Its regex is `/\bAI[\s-]*automation\b/i` — which matches `ai-automation` (the kebab-case form an HTML id would use) but NOT `ai-workflow-automation` because the word `workflow` between `ai` and `automation` breaks the regex's positional adjacency.
+
+If you rename the anchor to `ai-automation` you will trigger the linter on every page that links to that anchor (4+ pages today). See [[linter#pattern-catalog]] for the full pattern.
+
+The page hero on `services.html:88-99` has three anchor buttons jumping to these IDs:
+
+```html
+<a href="#ai-development">AI Software Development</a>
+<a href="#ai-training">AI Training</a>
+<a href="#ai-workflow-automation">AI Workflow Automation</a>
+```
+
+Index and small-business pages link to the same anchors with `href="services.html#ai-development"` and so on.
+
+---
+
+## Header + nav consistency
+
+Every page repeats the same header structure. There's no template engine — drift between pages is a maintenance hazard.
+
+### Desktop nav
+
+Every page's desktop nav (`<nav class="hidden md:flex items-center gap-8">`) should list these links in order:
+
+1. Services
+2. Small Business
+3. About
+4. Pricing
+5. Contact
+6. Client Portal (external link to `https://admin.williamtucker.ca/login`)
+7. Book a Call (CTA button, gold fill)
+
+**Known historical drift:** `privacy.html` was missing the Client Portal link in both desktop and mobile nav as of the 2026-05-18 audit. If unfixed, that's the only page out of compliance with this rule.
+
+### Mobile nav (hamburger)
+
+Same 7 links in the same order, in the mobile menu drawer (`<nav class="flex flex-col px-4 py-4 gap-4">` inside `<div id="mobile-menu">`).
+
+### Active-page indicator
+
+The link to the current page uses `class="text-gold font-medium"` (gold text) instead of `class="text-white hover:text-gold font-medium"`. So on `services.html`, the Services link is gold; on `contact.html`, the Contact link is gold.
+
+### Hamburger touch target
+
+The mobile hamburger button (`<button id="mobile-menu-button">`) currently uses `class="md:hidden text-white p-2"` on every page. Apple HIG minimum is 44×44 px — `p-2` with a 24×24 icon renders at ~40 px, just under the floor. Open backlog item if a future mobile-polish pass.
+
+---
+
+## Footer consistency
+
+Three columns:
+
+1. **Logo + tagline** — "AI-accelerated software development, training & workflow automation" (current tagline as of 2026-05-18; old tagline "Legacy modernization & AI consulting" should be banished by linter or doc review)
+2. **Quick Links list** — Services / Pricing / About / FAQ / Contact / Privacy Policy / Client Portal (7 links)
+3. **Connect list** — LinkedIn / GitHub / Email
+
+**Known historical drift:** As of the 2026-05-18 audit, the Quick Links column was missing the Client Portal `<li>` on `pricing.html`, `faq.html`, and `small-business.html`. The other 5 pages have it. Bottom-bar line includes copyright + Privacy Policy backlink — consistent across all 8.
+
+---
+
+## Breakpoint discipline (mobile-first)
+
+<!-- verified-against: contact.html:97 (py-8 md:py-16) and css/styles.css ?v=20260517b on 2026-05-18 -->
+
+Tailwind v4. Breakpoints:
+- Mobile (`< 640px`): no prefix — base classes apply
+- `sm:` ≥ 640px
+- `md:` ≥ 768px (this is the practical desktop boundary — iPhones are always below)
+- `lg:` ≥ 1024px
+- `xl:` ≥ 1280px
+
+The mobile-specific patterns the contact page incident drove home (see [[deploy#debugging-cache-problems-the-2026-05-17-playbook]]):
+
+### Pattern 1: order-swap on a 2-column grid
+
+When a desktop two-column layout should reorder on mobile, use Tailwind's `order-*` utilities on the grid children:
+
+```html
+<div class="grid grid-cols-1 md:grid-cols-2 gap-12">
+  <div class="order-2 md:order-1"> <!-- second on mobile, first on desktop --> </div>
+  <div class="order-1 md:order-2"> <!-- first on mobile, second on desktop --> </div>
+</div>
+```
+
+Live example: `contact.html:107-141` — the "How This Works" steps go below the form on mobile so the user reaches the submit button without scrolling past the explanation.
+
+### Pattern 2: compressed mobile padding
+
+When section padding is too generous on mobile, compress with `py-8 md:py-16` (saves ~64px) and shrink the heading scale with `text-3xl md:text-4xl` (saves ~12px):
+
+```html
+<section class="py-8 md:py-16">
+  <h1 class="text-3xl md:text-4xl font-bold ...">Heading</h1>
+</section>
+```
+
+Live example: `contact.html:97-101`.
+
+### Pattern 3: hidden-on-desktop affordance
+
+When a mobile-only hint is needed (e.g., a "tap to reveal" cue for hover-driven UI), use `md:hidden`:
+
+```html
+<p class="md:hidden text-xs text-red-400">↓ Tap to see the fix</p>
+```
+
+**Gotcha:** if a page-level inline `<style>` block also sets `display: block` on the same selector unconditionally, the inline rule's specificity (0,2,0 for a 2-class selector) will beat Tailwind's `.md\:hidden` (0,1,0) and the hint shows on desktop too. Solution: wrap the inline rule in `:where()` to drop specificity to (0,0,0), or move the rule into a `@media (max-width: 47.99rem)` block. Cite: small-business.html (current state has the corrected `:where()` form).
+
+---
+
+## Chatbot widget loading
+
+`js/chatbot.js` is the floating-bottom-right chat widget. It loads on every page EXCEPT `contact.html` (which has its own form as the primary CTA).
+
+Page → script reference:
+- `index.html`, `services.html`, `pricing.html`, `about.html`, `faq.html`, `privacy.html` → `<script src="js/chatbot.js?v=2"></script>`
+- `small-business.html` → `<script src="js/chatbot-demo.js?v=2"></script>` (the inline demo widget on the page itself, distinct from the floating button)
+- `contact.html` → no chatbot script
+
+The `?v=2` query is a static cache-buster — it's been at `v=2` for a while. If JS changes, bump it like the CSS one. See [[deploy#css-cache-busting-discipline]] for the same pattern applied to JS files (the rule generalizes — any static asset whose contents change without the URL changing is a cache trap).
+
+---
+
+## Cache-busting in HTML (mirror of deploy doc)
+
+Every page's stylesheet link has a version query:
+
+```html
+<link rel="stylesheet" href="css/styles.css?v=20260517b" />
+```
+
+When CSS output changes (new utility classes used, dropping a class), bump `v=YYYYMMDDx` ON ALL 8 PAGES — not just the page you're editing. The full procedure lives in [[deploy#how-to-bump-correctly]]. The 2026-05-17 incident's most damaging sub-failure was bumping the version on only one page.
+
+---
+
+## Reusable structural patterns
+
+- **Sticky header.** Every page: `<header class="sticky top-0 z-50 bg-navy">` with `h-16` (64 px). This eats ~64 px from every page's usable viewport.
+- **Section alternation.** White → off-white (`#f8f9fa`) → navy → white, repeated down. Per [[visual-system]], never three same-color surfaces in a row.
+- **Card pattern.** `border border-gray-200 rounded-lg p-8` for default cards. Highlighted cards use `border-2 border-gold` plus an absolute-positioned "Most Requested" badge.
+- **Eyebrow pill.** A small uppercase label above each track section heading: `<span class="inline-block bg-gold text-navy text-xs font-bold uppercase tracking-widest px-3 py-1 rounded-full mb-4">Track 1</span>`.
+
+---
+
+## Anti-patterns to refuse
+
+- **Don't reintroduce a `case-studies.html` or `checklist.html`.** Both deleted intentionally. See `project-site-no-work-samples` memory.
+- **Don't rename a section anchor without checking the linter.** `ai-automation` would re-trigger the credibility linter on every page that links to it.
+- **Don't change one page's nav without updating all 8.** There's no shared template — drift sticks.
+- **Don't add a new page without registering it** in `_index.md`, `doc-ownership.yml`, AND this doc's page inventory.
+
+---
+
+## Backlog
+
+- Pre-existing nav gaps (privacy missing Client Portal; pricing/faq/small-business missing it in footer) deserve a one-PR cleanup. Tracked in main `_backlog.md`.
+- The repeated nav block across 8 files is the strongest case for introducing a tiny build-time HTML partial system. Not done; cost of doing it ≈ cost of the next 5 nav-drift incidents.
+- `privacy.html`'s reference to Formspree + Calendly is currently stale; the contact form actually posts to `/api/contact` (see [[contact-flow]]). The privacy notice needs a rewrite naming Supabase + Resend + Cloudflare + Railway.

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -1,0 +1,172 @@
+---
+title: Positioning & Brand Voice
+domain: positioning
+status: active
+last-reviewed: 2026-05-18
+verified-against:
+  - source: 8 HTML pages on 2026-05-18
+  - prompt: prompts/chatbot-system.md
+  - profile: D:/code/cv/PROFILE.md §10 framing rules
+---
+
+# Positioning & Brand Voice
+
+> **What's in this doc:** the three AI service tracks, the credibility framing rules every copy edit must follow, who the site is for, the brand voice in three words, what the site explicitly is NOT, and the discipline rule that prevents merging to master without local-test approval.
+>
+> **What's NOT:** the visual design system (→ [[visual-system]] when written; for now see `DESIGN.md` + `DESIGN.json`), the page-level structure (→ [[pages]]), the linter that enforces the framing rules at build time (→ [[linter]]).
+
+The site is the entire top-of-funnel for a one-engineer consulting practice in Kelowna, BC. There is no paid acquisition, no sales team, no SDR. Most clients arrive via referral. The site's job is **service confirmation + booking, not credibility argument** — the referral already did the credibility work.
+
+---
+
+## The three service tracks
+
+<!-- verified-against: services.html sections #ai-development, #ai-training, #ai-workflow-automation on 2026-05-18 -->
+
+| Track | Pitch | Pricing anchors |
+|---|---|---|
+| **Track 1 — AI-Accelerated Software Development** | Custom software, modernizations, and apps. AI agents handle the boilerplate; William handles engineering, planning, and review. Client owns the codebase at handoff. | $2,500 audit · $10,000–$30,000 build · $1,500/mo ongoing support |
+| **Track 2 — AI Training** | Hands-on AI training from a daily practitioner. In-person in Kelowna or online. 1:1, group workshops, or custom team curriculum. | $275 per 90-min session · $2,500 half-day · $4,000 full-day · from $7,500 custom curriculum · $1,250/mo retainer |
+| **Track 3 — AI Workflow Automation** | AI plugged into the tools and systems the client already uses — chatbots, custom integrations, internal tooling, agents, MCP servers. | Free 30–60 min discovery · $2,500 small build · $7,500 medium build · $1,000/mo maintenance |
+
+These exact prices appear in two surfaces simultaneously: `pricing.html` and `prompts/chatbot-system.md`. **When pricing changes, BOTH surfaces must be updated together.** The linter doesn't catch numeric drift; agent discipline does.
+
+Each track has a section ID used as an anchor across multiple pages — see [[pages#anchor-naming]]. Track 3 specifically uses `#ai-workflow-automation` (not `#ai-automation`) to avoid colliding with the credibility linter.
+
+---
+
+## Framing rules (the credibility floor)
+
+These rules are the source of truth for every copy edit. The linter enforces most of them at build time — see [[linter#pattern-catalog]] — but the discipline must be in the head of whoever's writing the copy, not just in the regex.
+
+### Years of experience
+
+**12+ years professional software experience** (since 2013). Never "15+", never inflate. Linter pattern `years-inflated` blocks anything from 13+ through 19+.
+
+### AI framing
+
+**AI-accelerated, never AI-replaced.** Describe AI work as augmented senior engineering. The line items work-by-line: AI handles boilerplate, research, mechanical edits; William handles planning, architecture, debugging, judgment, accountability. Linter patterns `ai-replaced`, `ai-replaces-engineers`, and `ai-automation` enforce variants of this.
+
+The word "automation" is forbidden as a descriptor of *his work* (`ai-automation` pattern), but Track 3 is legitimately called **AI Workflow Automation** because "workflow" sits between "AI" and "automation" and breaks the regex. The phrase "workflow automation" is fine; "AI automation" alone is not.
+
+### Currently dual-role
+
+William is currently **both** a Programmer/Analyst at Vancouver Island University (Jul 2016 – Present) AND the founder of William Tucker Solutions (2026 – Present). WTS is not his sole employment. Don't imply otherwise in bios.
+
+### RoomBooking status
+
+**In QA, not production.** Go-live is blocked on organizational approval, not engineering work. Frame as *"delivered end-to-end in 5 days as sole author; currently in QA and technically ready for production. Reference available on request."* Linter pattern `room-booking-prod` enforces this — and the doubles as an accountability signal in copy.
+
+### BIS (Facilities Information System) timeline
+
+**~7 weeks of AI-augmented development, 66 commits across 14 branches.** Not "2 days" — that was an earlier draft's compressed claim. The 7-week number with a real commit history is a *stronger* claim than "2 days" because it demonstrates planned, iterated, tested work. Linter pattern `bis-compressed` blocks the compressed version.
+
+### Stack gaps (honest)
+
+Acknowledge directly, don't infer transferable skills from adjacent tech:
+
+- **No production MySQL.** PostgreSQL via Supabase is the closest equivalent.
+- **No AWS.** Cloud infra is Vercel + Railway + Supabase + DreamHost.
+- **No Salesforce / Apex / Flows.**
+- **No native mobile (iOS/Android).** PWA exposure only.
+- **No modern PHP framework experience.** Only PHP exposure is a 2012 TRU co-op.
+
+Linter patterns `mysql-prod`, `aws-prod`, `salesforce-prod` enforce these as proximity rules (they fire if the named tech appears near "production" on the same line/within a window).
+
+### AI training credentials
+
+William is **not a certified AI trainer**. Framing for Track 2 is "active daily practitioner who teaches what he ships with," not "credentialled." The chatbot prompt and `faq.html:142` both quote this rule; both are linter-suppressed because they legitimately quote the forbidden phrase to forbid it. Linter pattern `ai-certified` blocks the credential claim; `quantified-training` blocks "trained N students" counts.
+
+---
+
+## Audience
+
+The site is **referral-driven, local Kelowna SMB-first**. Most visitors arrive convinced; the site's job is to confirm services exist, let them pick the right track, and let them book a call.
+
+The previous dual-track audience model ("Legacy modernization" buyers + "AI consulting for finance teams") is **obsolete as of PR #4 (2026-05-15)**. The three-track structure replaced it. If you encounter older docs (`PRODUCT.md` Users section, archived specs) describing two tracks, that's stale — fix it forward.
+
+Implications for any copy edit:
+- **Plain outcome-language over stack details.** Kelowna SMB owners don't care about Blazor vs Next.js — they care about "we'll automate your invoicing."
+- **No "12+ years senior engineering" piled everywhere.** One mention is plenty.
+- **No testimonial / "trusted by" / proof-reel modules.** Credibility comes from the referral. Linter pattern `credibility-theater` enforces this.
+- **No buzzword soup** ("revolutionary AI", "industry-leading", "cutting-edge"). Linter pattern `buzzword-soup` enforces this.
+- **CTAs lead to a discovery call.** Don't try to close on the page.
+
+The memory `project-site-audience` codifies this for future agents.
+
+---
+
+## Brand voice in three words
+
+**Competent. Plainspoken. Unhyped.**
+
+A senior staff engineer talking to another technical buyer — or to a small-business owner who hates being marketed at. Confident without performing confidence. Specific over abstract. Numbers and names over adjectives.
+
+Concrete tactical applications:
+
+- **Verbs not vibes.** "Build", "rebuild", "integrate", "audit", "train" — not "transform", "harness", "unlock", "synergize".
+- **Present tense.** "I build X" not "We could help you build X."
+- **First person singular.** "I" / "me" — not "we" / "our team". One engineer; the design system reinforces this (no oversized founder photo, no fake team page).
+- **Numbers anchored to real artifacts.** "7 weeks (66 commits, 14 branches)" beats "fast turnaround." Round-number marketing metrics get cut.
+- **Friendly, not detached.** Plainspoken doesn't mean cold. The chatbot system prompt explicitly says "friendly, plain-spoken, confident — the kind of person you'd want to grab a coffee with."
+
+---
+
+## What the site explicitly is NOT
+
+Three anti-references (carried from `DESIGN.md` and `PRODUCT.md`):
+
+1. **The "AI consultancy" Squarespace template.** Purple/teal gradient hero, glowing brain-circuit stock photo, "We harness the transformative power of AI to unlock value." Decorated promise, no specific referent.
+2. **The LinkedIn-influencer landing page.** Oversized founder photo, hand-drawn arrows, "I helped 47 founders 10x their revenue", neon CTAs, fake-handwritten testimonials.
+3. **The Big-4 services page** (Accenture, Deloitte, EY AI offerings). Slide-deck aesthetics, "transformation journeys", "synergies", six-figure procurement vibe.
+
+The connecting thread is **decoration without referent**. WTS visuals and copy must read as proof, not as marketing of proof.
+
+---
+
+## Deploy discipline (do not bypass)
+
+These rules are codified in memory but written here so they're vault-discoverable:
+
+### Never merge to master without local-test approval
+
+`master` push triggers a DreamHost deploy. There is no preview / staging slot. Lint passing is not the same as William having seen the rendered pages on a real device. See `feedback-local-test-before-merge` memory and [[deploy#debugging-cache-problems-the-2026-05-17-playbook]].
+
+When implementing a UI change, end the work with *"Want to test locally before I open the PR / merge?"* — not *"Pushing now."*
+
+### Never `git add -A` in this repo
+
+The workspace `CLAUDE.md` says it, the global Bash guidance says it, the WTS `CLAUDE.md` says it. The 2026-05-17 incident proved it: `git add -A` swept in 134 local-tooling files (`.agents/`, `.claude/skills/`, `.superpowers/`, business-sensitive docs, cross-project screenshots). **Always specific file paths.**
+
+The `.gitignore` added in PR #7 is a safety net for the worst cases but it isn't comprehensive — discipline still matters. See [[deploy#the-rule]] for the cache-buster bump procedure that's the most common multi-file operation in this repo, and the proper way to do it without `-A`.
+
+### Refer-then-update doc discipline
+
+When a copy / structural change is made (e.g., the three-track reframe), the corresponding vault docs MUST be updated in the same PR. See [[vault-conventions#touching-a-doc]] for the per-doc rules. Specifically:
+- New tracks / new pages / removed pages → update [[pages]]
+- New positioning / new audience / new framing rules → update this doc
+- New CSS class usage that changes `css/styles.css` → update [[deploy#css-cache-busting-discipline]] is not affected, but the cache-buster bump is required and tracked in [[deploy]]
+
+If the PR doesn't update affected docs, it shouldn't merge.
+
+---
+
+## Source-of-truth hierarchy (for facts about William)
+
+Vault docs document **the codebase**. Facts about William's career, projects, employment history, credentials, and stack live in **`D:\code\cv\PROFILE.md`** (outside this repo). PROFILE.md §10 has the framing rules verbatim; if this doc and PROFILE.md ever conflict on a framing rule, PROFILE.md wins and this doc gets corrected.
+
+Currently this doc paraphrases PROFILE.md §10 — if the rules change there, they need to be re-synced here.
+
+---
+
+## Anti-patterns
+
+| Don't | Do |
+|---|---|
+| Add a "Track 4" without explicit user request | Stick with three — they're the entire positioning |
+| Pile "12+ years senior engineering" on every page | One mention is plenty |
+| Add testimonials, "trusted by" badges, or proof modules | None — referral-driven means credibility lives off-site |
+| Use the word "automation" to describe William's work | He doesn't automate — he ships engineering work with AI assist |
+| Rename `#ai-workflow-automation` to `#ai-automation` | The linter will fire on every cross-page link |
+| Quote pricing numbers from memory in a draft | Read `pricing.html` or `prompts/chatbot-system.md` and copy verbatim |
+| Update positioning copy without updating both surfaces | The chatbot system prompt at `prompts/chatbot-system.md` mirrors site copy — if they drift, the chatbot says one thing and the page says another |

--- a/docs/visual-system.md
+++ b/docs/visual-system.md
@@ -1,31 +1,289 @@
 ---
 title: Visual System
 domain: visual-system
-status: stub
+status: active
 last-reviewed: 2026-05-18
+verified-against:
+  - source: DESIGN.md (full spec) + DESIGN.json (tokens)
+  - source: tailwind.config.js (color/font extensions)
+  - source: src/input.css (base layer)
+  - sample: css/styles.css (compiled output) on 2026-05-18
 ---
 
 # Visual System
 
-> **What's in this doc:** _(stub — will document the design system once first edited)._
+> **What's in this doc:** the engineer's-statement visual posture, the two-color palette (Drafting Navy + Solder Gold), the single-typeface system (Inter), the flat-by-default elevation model, the component vocabulary (buttons, pills, cards, inputs, nav, stat strip), the named rules that govern usage, and the anti-references the system actively rejects.
 >
-> **What's NOT:** the positioning copy (→ [[positioning]]), the page structure (→ [[pages]]), the visual anti-references in `PRODUCT.md` until they're migrated here.
+> **What's NOT:** the positioning copy the visuals support (→ [[positioning]]), the page-level structure / breakpoints / mobile patterns (→ [[pages]]), or the build pipeline that compiles Tailwind to CSS (→ [[deploy]]).
 
-This doc is a placeholder. The full visual system — colors, typography, components, elevation, animation rules, anti-references — currently lives in `DESIGN.md` and `DESIGN.json` at the repo root.
+The visual system reads as a technical document, not a marketing page. Every element either carries information or steps aside. Two colors, one typeface, one shadow value. That's the posture; everything below is the playbook.
 
-When the visual system is next edited substantively, migrate its content into this doc using the [[vault-conventions]] format: frontmatter, "What's in / What's NOT" callout, code citations to `tailwind.config.*` and `src/input.css` where applicable.
+---
 
-## Current source of truth (legacy)
+## North Star
 
-- `DESIGN.md` — full visual spec, drafting-studio palette, type hierarchy, component rules, anti-references
-- `DESIGN.json` — machine-readable design tokens (colors, typography scales, spacing, components)
-- `src/input.css` — Tailwind v4 input that compiles to `css/styles.css`
+**Creative direction:** "The Engineer's Statement."
 
-Things to verify when migrating:
-- Are the colors in `DESIGN.json` still the actual colors used in `css/styles.css`? (Run a grep for `#d4a843` and `#1a2332`.)
-- Does the type scale in `DESIGN.json` match what's actually used in HTML (`text-4xl`, `text-3xl`, etc.)?
-- Are the anti-references (Squarespace template / LinkedIn-influencer / Big-4) still accurate descriptions of "what NOT to look like"? They've been stable, but periodically re-verify the framing still matches the market.
+Drafting Navy + Solder Gold reference engineering conventions (blueprint ink, soldered brass), not financial-services convention (corporate navy + luxury gold). Inter at sharp weights with generous line height keeps every page closer to a printed spec sheet than a product landing page. The site sells competence as proof. The visuals have to read the same way.
 
-## Note
+The source-of-truth file for the rules is **`DESIGN.md`** at the repo root (~275 lines). Machine-readable tokens live in **`DESIGN.json`** (frontmatter of `DESIGN.md`). Tailwind picks up the `navy`/`gold` palettes via `tailwind.config.js:6-19`. The base layer (body font, heading color, link transition) is set in `src/input.css:5-15`.
 
-`DESIGN.md` line 3 currently has a stale `description:` frontmatter field that says "legacy modernization + AI consulting." Fix that next time you're in the file (now reframed as three AI tracks — see [[positioning]]).
+When this doc and `DESIGN.md` conflict on a rule, `DESIGN.md` is the source. This doc summarizes; `DESIGN.md` has the full prose.
+
+---
+
+## Colors
+
+<!-- verified-against: tailwind.config.js:6-19, DESIGN.json frontmatter (DESIGN.md:4-18), and compiled css/styles.css on 2026-05-18 — all three agree -->
+
+Two-color system. Drafting Navy carries surface; Solder Gold carries voice. Page Off-White separates white-on-white sections.
+
+### Primary surfaces
+
+| Token | Hex | Tailwind class | Where it shows up |
+|---|---|---|---|
+| Drafting Navy | `#1a2332` | `bg-navy`, `text-navy`, `border-navy` | Sticky header, hero band, footer, navy CTA section |
+| Drafting Navy Light | `#243044` | `bg-navy-light` | Mobile menu drawer; hover state on navy surfaces |
+| Drafting Navy Dark | `#111827` | `bg-navy-dark` | Reserved for deep-fill blocks; rarely used currently |
+
+### Voice accent
+
+| Token | Hex | Tailwind class | Where it shows up |
+|---|---|---|---|
+| Solder Gold | `#d4a843` | `bg-gold`, `text-gold`, `border-gold` | Primary buttons, eyebrow pills, link emphasis, statistic underline |
+| Solder Gold Light | `#e0be6a` | `bg-gold-light` | Primary button hover |
+| Solder Gold Dark | `#b8912e` | `text-gold-dark` | Inline link color on light backgrounds (where default Solder Gold would lose contrast) |
+
+### Neutrals
+
+| Token | Hex | Tailwind class | Where it shows up |
+|---|---|---|---|
+| Page Off-White | `#f8f9fa` | inline `style="background-color: #f8f9fa;"` (NOT a tailwind token — applied inline) | Alternating section background; "next page" signal in long scrolls |
+| Page White | `#ffffff` | `bg-white` | Card surface + primary section background |
+| Ink (gray-700) | `#374151` | `text-gray-700` | Default body copy color |
+| Ink (gray-200) | `#e5e7eb` | `border-gray-200` | Dividers, card borders when used |
+
+### Named rules
+
+These are non-negotiable. Each is stated in `DESIGN.md`; the linter doesn't enforce them, but agent discipline must.
+
+**The One Voice Rule** (`DESIGN.md:156`): Solder Gold appears on ≤10% of any screen surface. Reserve it for CTAs, eyebrow pills, single-word emphasis in headlines, and link affordances. If gold is doing more than carrying brand voice, the page is shouting.
+
+**The Two-Surface Rule** (`DESIGN.md:158`): Sections alternate between Page White and Page Off-White, OR between Page White and Drafting Navy. **Never three surface tones in a row** without a structural reason. Note: per the audit on 2026-05-18, `small-business.html` has two consecutive `bg-white` sections (the new "Three ways I help" block + the Quiz block) — flagged in `_backlog.md` as a polish item.
+
+**The No-Tinted-Card Rule** (`DESIGN.md:160`): Cards are always Page White. Cards on Page Off-White sections gain elevation via shadow only — never by tint. Tinted cards on tinted sections collapse contrast.
+
+---
+
+## Typography
+
+<!-- verified-against: tailwind.config.js:21-23 (fontFamily.sans = Inter), src/input.css:7 (body @apply font-sans), and DESIGN.json typography block on 2026-05-18 -->
+
+**Single typeface.** Inter, with `system-ui, sans-serif` fallback. Four weights loaded: 400 / 500 / 600 / 700. The hierarchy is built from weight + scale, not from contrasting families.
+
+### Hierarchy (eight roles)
+
+| Role | Weight | Size | Line height | Tailwind |
+|---|---|---|---|---|
+| Display | 700 | `clamp(2.25rem, 5vw, 3.75rem)` | 1.1 | hero `<h1>` only, often `text-4xl md:text-5xl lg:text-6xl` |
+| Headline | 700 | `clamp(1.875rem, 3vw, 2.25rem)` | 1.2 | section `<h2>`, often `text-3xl md:text-4xl` |
+| Title | 600 | 1.25rem | 1.4 | card `<h3>`/`<h4>`, often `text-xl` or `text-2xl` |
+| Body Large | 400 | 1.125rem | 1.625 | hero subhead / lead paragraph, often `text-lg md:text-xl` |
+| Body | 400 | 1rem | 1.625 | default paragraph, `text-base` (color: `text-gray-700` via base layer in `src/input.css`) |
+| Label | 700 | 0.75rem | letter-spacing 0.1em | eyebrow pills, classifier pills, stat captions — often `text-xs font-bold uppercase tracking-widest` |
+
+The base layer in `src/input.css:5-15` sets:
+- `body` → font-sans (Inter), text-gray-800, antialiased
+- `h1, h2, h3, h4` → text-navy (color override)
+- `a` → transition-colors duration-200 (color-only animation on links)
+
+### Named rules
+
+**The Single-Voice Rule** (`DESIGN.md:179`): No second typeface for accents. No serif display, no monospace stat readouts, no script signature blocks. Inter does every job. Hierarchy = weight (400 → 700) × scale (1rem → ~3.75rem), never family contrast.
+
+**The Reading-Width Rule** (`DESIGN.md:181`): Body copy that wraps more than two lines is constrained to 65–75 characters per line. Wider lines read as PDF dumps, not as thoughtful writing. Practical pattern: wrap paragraphs in `<div class="max-w-2xl">` or similar.
+
+---
+
+## Elevation
+
+<!-- verified-against: DESIGN.md:185-195 and grep "box-shadow" css/styles.css → exactly one Card Lift value -->
+
+Flat-by-default. Exactly one shadow value in the entire vocabulary, in exactly one role.
+
+**Card Lift:** `box-shadow: 0 1px 3px 0 rgba(0,0,0,0.1), 0 1px 2px -1px rgba(0,0,0,0.1)` — Tailwind class `shadow`.
+
+Used only on Page White cards sitting over Page Off-White sections. Purely structural separation. **Never** on dark backgrounds. **Never** on inputs, pills, or buttons. **Never** as decoration.
+
+### Named rules
+
+**The Flat-By-Default Rule** (`DESIGN.md:193`): Every surface flat at rest. The single Card Lift shadow separates cards from their off-white parent — not depth-as-decoration. If a designer reaches for a shadow to "make something pop," the right answer is almost always to change weight, color, or spacing instead.
+
+**The No-Glow Rule** (`DESIGN.md:195`): Glowing borders, soft focus halos, ambient drop shadows under accent elements — all forbidden. The Squarespace-template anti-reference (see below) is the nearest neighbour, and the system rejects glow as a category.
+
+---
+
+## Components
+
+The system's component vocabulary as it lives in HTML + Tailwind today. When components grow custom variants (more than the two-tier button system, more than the two pill roles), update this section.
+
+### Buttons
+
+Two tiers, same shape, same padding, different fill.
+
+**Primary** (gold fill, navy text):
+```html
+<a class="inline-block bg-gold text-navy font-semibold px-8 py-4 rounded hover:bg-gold-light transition-colors duration-200">
+  Book a Free Discovery Call
+</a>
+```
+
+**Ghost** (transparent fill, gold border):
+```html
+<a class="inline-block border-2 border-gold/60 text-gold font-semibold px-8 py-4 rounded hover:bg-gold/10 transition-colors duration-200">
+  See the Three Tracks →
+</a>
+```
+
+Shape: `rounded` (0.25rem) — slight curve reads as form-control, not as marketing pill.
+Padding: vertical `1rem` (`py-4`), horizontal `2rem` (`px-8`). Large CTAs may use `px-10`.
+Transition: 200ms color-only, no transform.
+
+### Pills
+
+Two distinct roles, never visually conflated.
+
+**Eyebrow Pill** — small uppercase tag above a heading. Solder Gold/15 fill, Solder Gold text, `rounded-full`, label typography:
+```html
+<span class="inline-block bg-gold/15 text-gold text-sm font-semibold uppercase tracking-widest px-3 py-1 rounded-full mb-5">
+  AI for Local Business
+</span>
+```
+Always uppercase, always taxonomic — names what comes next. Never decorative.
+
+**Classifier Pill** — discriminates between buyer-track sections. Gold solid OR Navy solid, opposing text color, same `rounded-full` + label typography:
+```html
+<span class="inline-block bg-gold text-navy text-xs font-bold uppercase tracking-widest px-3 py-1 rounded-full mb-4">
+  Track 1
+</span>
+```
+Gold pill = primary / featured. Navy pill = secondary / "also". Pure information design.
+
+### Cards
+
+`rounded-lg` (0.5rem) corners, Page White fill, internal padding `p-8` (2rem all sides), no border (rely on shadow + white-on-off-white contrast). For highlighted cards, switch to `border-2 border-gold` + absolute-positioned "Most Requested" badge:
+
+```html
+<div class="border-2 border-gold rounded-lg p-8 mb-8 relative">
+  <div class="absolute -top-3 left-8">
+    <span class="bg-gold text-navy text-xs font-semibold px-3 py-1 rounded-full">Most Requested</span>
+  </div>
+  ...
+</div>
+```
+
+Live examples: `services.html:115-156` (Build card), `pricing.html:114-150` (Build pricing card).
+
+### Inputs
+
+Single style, optimized for the email-capture and contact forms.
+- Border: 1px `border-gray-300` (Ink-300)
+- Background: Page White
+- Radius: `rounded-lg` (0.5rem)
+- Padding: `py-3 px-4` (~12px vertical, 16px horizontal)
+- Focus: 2px Solder Gold ring (`focus:ring-2 focus:ring-gold`), transparent border (`focus:border-transparent`)
+
+The Solder Gold focus ring is the **only** place on the site where a glow-adjacent treatment is permitted. It's purely functional (focus indication for accessibility).
+
+### Navigation (sticky header)
+
+Drafting Navy background, white wordmark with Solder Gold "S" letter-color split (signals the WTS abbreviation without an external logo). Default link state: white text, `font-medium`. Hover: Solder Gold, 200ms color-only.
+
+The CTA button at the right edge of the desktop nav uses the Primary Button variant. The mobile hamburger reveals a Drafting Navy Light drawer with the same link list vertically stacked. See [[pages#header--nav-consistency]] for the per-page consistency rules.
+
+### Stat Strip (signature component)
+
+The three-up statistics block on the homepage (`index.html:236-249`):
+- Container: Ink-200 1px border, `rounded-xl` (0.75rem), three columns separated by 1px internal dividers. No shadow.
+- Cell: vertical center-aligned, `py-10` (40px vertical padding). Stat number is `text-4xl font-bold text-navy`, 8px gap, caption is `text-gray-600`.
+
+**Strict invariant:** every number in this strip references a verifiable artifact. Round numbers without referents are forbidden. The 2026-05-18 audit flagged the current middle stat ("3 / Service tracks: dev, training, automation") as tautological — see `_backlog.md` for the replace-with-a-real-stat backlog item.
+
+---
+
+## Anti-references
+
+These are the visual postures the system **actively rejects**. Stated verbatim from `DESIGN.md:126` and `PRODUCT.md`.
+
+1. **The "AI consultancy" Squarespace template.** Purple/teal gradient hero, glowing brain-circuit stock photo, evergreen-stock illustrations, copy like *"We harness the transformative power of AI to unlock value."* Decorated promise with no specific referent.
+2. **The LinkedIn-influencer landing page.** Oversized founder photo, hand-drawn arrows, *"I helped 47 founders 10x their revenue"*, neon CTAs, fake-handwritten testimonials. Performative confidence aimed at a different buyer.
+3. **The Big-4 services page** (Accenture, Deloitte, EY AI offerings). Corporate stock photography, slide-deck aesthetics, abstract nouns like *"synergies"* and *"transformation journeys"*, zero specifics, six-figure procurement vibe.
+
+The connecting thread is **decoration without referent**. WTS visuals must read as proof, not as marketing of proof.
+
+The credibility linter (see [[linter#pattern-catalog]]) enforces the verbal correlates — buzzword-soup pattern, credibility-theater pattern, AI-replaced patterns — but the visual postures are agent-discipline-only.
+
+---
+
+## Do / Don't (verbatim from DESIGN.md:255-275)
+
+### Do
+
+- Use Solder Gold on ≤10% of any screen surface; reserve it for CTAs, eyebrow pills, single-word emphasis, link affordances.
+- Alternate Page White ↔ Page Off-White (or Page White ↔ Drafting Navy) for section rhythm.
+- Lead every major section with a labelled eyebrow pill.
+- Keep body copy at 65–75 characters per line.
+- Hold the type system to Inter, four weights, eight roles.
+- Ground every statistic in a verifiable artifact. Prefer specific numbers (`705,714 lines`) to round ones (`750k+`).
+- Honor `prefers-reduced-motion` on every transition.
+
+### Don't
+
+- Introduce gradient text, gradient buttons, or gradient hero backgrounds.
+- Introduce a second typeface for "personality" (no serif display, no script, no mono accent).
+- Add ambient drop-shadow, glassmorphism, glow halos, or backdrop-blur effects.
+- Use a brain icon, abstract circuit illustration, generic AI stock photography, or any "we harness the power of AI" framing.
+- Use a hand-drawn arrow, oversized founder portrait, or neon-accent CTA.
+- Use abstract enterprise nouns (*"synergies"*, *"transformation journey"*, *"value unlock"*).
+- Use round-number marketing metrics without a referent (`10x`, `400% improvement`, `100s of clients`).
+- Style cards with internal tints, nested cards, or borders combined with shadow.
+- Introduce a second elevation level.
+
+---
+
+## Accessibility commitments
+
+<!-- verified-against: DESIGN.md does not specify per-element AA verification; PRODUCT.md §Accessibility (lines 57-70) is the source -->
+
+Target: **WCAG 2.2 AA** for all public marketing pages. Concrete commitments stated in `PRODUCT.md` lines 61-69:
+
+- Body text contrast ≥ 4.5:1; large heading contrast ≥ 3:1
+- Every interactive element keyboard-reachable, visible focus ring (not removed for aesthetic reasons)
+- Meaningful images carry alt text; decorative use empty alt or `aria-hidden`
+- Form fields have labels; error messages readable by assistive tech
+- No content depends on color alone (status indicators pair color with text or icon)
+- `prefers-reduced-motion` honored on every transition (currently the chatbot widget JS uses 200ms color-only transitions and a typing-indicator bounce that could degrade — backlog item to verify)
+
+AAA is not a target (would over-constrain typography + color choices for marginal real-world benefit).
+
+---
+
+## Anti-patterns
+
+| Don't | Do |
+|---|---|
+| Add a new color outside the two-color palette | If a new role genuinely needs differentiation, use weight or scale, not color |
+| Reach for a shadow to "make something pop" | Change weight, color, or spacing instead. Cards on Off-White get the one Card Lift shadow; that's it |
+| Use `border-left: 4px solid gold` as a left-side accent on cards or alerts | Cards rely on shadow + contrast; alerts use neutral icons + color, not stripes |
+| Introduce a second typeface for "personality" | Inter does every job. If a role isn't expressible in Inter at one of the eight scales, the role is wrong |
+| Apply `text-gold` to a multi-sentence paragraph | Solder Gold is for single-word emphasis. A whole gold paragraph is a slop-test failure |
+| Add a `prefers-reduced-motion` exemption | All transitions must degrade gracefully or disable. This is an accessibility commitment |
+
+---
+
+## Backlog
+
+- `small-business.html` has two consecutive `bg-white` sections (audit 2026-05-18). Either insert a Page Off-White transition or accept the violation as a documented exception.
+- The middle stat strip cell ("3 service tracks") is tautological — replace with a verifiable artifact reference.
+- `prefers-reduced-motion` honoring in `js/chatbot.js` and `js/chatbot-demo.js` has not been verified. Audit on next chatbot edit.
+- A planned cheatsheet `docs/_cheatsheets/color-tokens.md` could distill the hex/token/Tailwind-class triple from this doc into a ≤30-line lookup. Hold off until the lookup proves repetitive.

--- a/docs/visual-system.md
+++ b/docs/visual-system.md
@@ -1,0 +1,31 @@
+---
+title: Visual System
+domain: visual-system
+status: stub
+last-reviewed: 2026-05-18
+---
+
+# Visual System
+
+> **What's in this doc:** _(stub — will document the design system once first edited)._
+>
+> **What's NOT:** the positioning copy (→ [[positioning]]), the page structure (→ [[pages]]), the visual anti-references in `PRODUCT.md` until they're migrated here.
+
+This doc is a placeholder. The full visual system — colors, typography, components, elevation, animation rules, anti-references — currently lives in `DESIGN.md` and `DESIGN.json` at the repo root.
+
+When the visual system is next edited substantively, migrate its content into this doc using the [[vault-conventions]] format: frontmatter, "What's in / What's NOT" callout, code citations to `tailwind.config.*` and `src/input.css` where applicable.
+
+## Current source of truth (legacy)
+
+- `DESIGN.md` — full visual spec, drafting-studio palette, type hierarchy, component rules, anti-references
+- `DESIGN.json` — machine-readable design tokens (colors, typography scales, spacing, components)
+- `src/input.css` — Tailwind v4 input that compiles to `css/styles.css`
+
+Things to verify when migrating:
+- Are the colors in `DESIGN.json` still the actual colors used in `css/styles.css`? (Run a grep for `#d4a843` and `#1a2332`.)
+- Does the type scale in `DESIGN.json` match what's actually used in HTML (`text-4xl`, `text-3xl`, etc.)?
+- Are the anti-references (Squarespace template / LinkedIn-influencer / Big-4) still accurate descriptions of "what NOT to look like"? They've been stable, but periodically re-verify the framing still matches the market.
+
+## Note
+
+`DESIGN.md` line 3 currently has a stale `description:` frontmatter field that says "legacy modernization + AI consulting." Fix that next time you're in the file (now reframed as three AI tracks — see [[positioning]]).

--- a/scripts/check-docs-freshness.mjs
+++ b/scripts/check-docs-freshness.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+// check-docs-freshness.mjs — pre-commit hook that prevents code-touches-doc
+// drift at the source.
+//
+// vault-doctor detects drift AFTER it happens (next CI run). This script
+// prevents the COMMIT that creates drift. For each staged code file, it
+// finds which doc owns that file path via `docs/_meta/doc-ownership.yml`,
+// then checks that the doc's frontmatter `last-reviewed` equals today —
+// OR that the doc itself is staged in the same commit (you're editing it
+// right now, presumably to reflect the code change).
+//
+// Usage:
+//   node scripts/check-docs-freshness.mjs        # check this repo's staged files
+//   node scripts/check-docs-freshness.mjs --help
+//
+// Install as a pre-commit hook:
+//   See templates/ci/pre-commit-hook.example.
+//
+// Bypass (legitimate WIP commits):
+//   git commit --no-verify
+//
+// Exit codes:
+//   0 — nothing to check, or all affected docs are fresh
+//   1 — at least one affected doc is stale (commit aborted)
+//   2 — fatal error
+//
+// Zero runtime deps — composes match-docs's routing helpers.
+
+import { promises as fs } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+import {
+  loadOwnership,
+  compileOwnership,
+  matchPathToDocs,
+  matchSqlToDocs,
+} from './match-docs.mjs';
+
+const HELP = `check-docs-freshness — prevent commits that touch code without updating the owning doc.
+
+USAGE
+  node scripts/check-docs-freshness.mjs
+  node scripts/check-docs-freshness.mjs --help
+
+EXIT CODES
+  0   pass
+  1   stale doc(s) — commit aborted
+  2   fatal (ownership file missing, etc.)
+
+BYPASS
+  git commit --no-verify
+`;
+
+const CWD = process.cwd();
+const TODAY = new Date().toISOString().slice(0, 10);
+
+function getStagedFiles() {
+  const out = execSync('git diff --cached --name-only --diff-filter=ACMR', {
+    cwd: CWD, encoding: 'utf8',
+  });
+  return out.split('\n').map(s => s.trim()).filter(Boolean);
+}
+
+// Mirrors vault-doctor's frontmatter-field reader but minimal — we only need
+// one specific field from one specific file at a time.
+async function readFrontmatterField(filePath, field) {
+  let content;
+  try {
+    content = await fs.readFile(filePath, 'utf8');
+  } catch {
+    return null;
+  }
+  const block = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!block) return null;
+  const line = block[1].match(new RegExp(`^${field}:\\s*(.+?)\\s*$`, 'm'));
+  return line ? line[1] : null;
+}
+
+async function main() {
+  if (process.argv.includes('--help') || process.argv.includes('-h')) {
+    console.log(HELP);
+    return 0;
+  }
+
+  const staged = getStagedFiles();
+  if (staged.length === 0) return 0;
+
+  let ownership;
+  try {
+    ({ ownership } = await loadOwnership());
+  } catch (err) {
+    console.error(`check-docs-freshness: ${err.message}`);
+    console.error('Skipping freshness check — pre-commit hook is a no-op until ownership is set up.');
+    return 0; // don't block commits in a half-bootstrapped project
+  }
+  const compiled = compileOwnership(ownership);
+  const sqlRoutingEnabled = compiled.some(c => c.dbObjects.length > 0);
+
+  const stagedSet = new Set(staged);
+  const affectedDocs = new Set();
+
+  for (const file of staged) {
+    for (const doc of matchPathToDocs(file, compiled)) {
+      affectedDocs.add(doc);
+    }
+    // SQL routing: if this staged file is a .sql file and SQL routing is
+    // enabled, parse it and add docs whose db_objects match.
+    if (sqlRoutingEnabled && file.endsWith('.sql')) {
+      let sql;
+      try {
+        sql = await fs.readFile(path.join(CWD, file), 'utf8');
+      } catch {
+        continue; // deleted or unreadable — skip
+      }
+      for (const doc of matchSqlToDocs(sql, compiled).keys()) {
+        affectedDocs.add(doc);
+      }
+    }
+  }
+
+  if (affectedDocs.size === 0) return 0;
+
+  const stale = [];
+  for (const doc of affectedDocs) {
+    const docPath = `docs/${doc}.md`;
+    // If the doc itself is in the staged set, the author is editing it now;
+    // skip the date check — they can bump last-reviewed in this commit.
+    if (stagedSet.has(docPath)) continue;
+    const lastReviewed = await readFrontmatterField(path.join(CWD, docPath), 'last-reviewed');
+    if (lastReviewed !== TODAY) {
+      stale.push({ doc, docPath, lastReviewed });
+    }
+  }
+
+  if (stale.length === 0) return 0;
+
+  console.error('');
+  console.error('check-docs-freshness: commit blocked.');
+  console.error('');
+  console.error(`The following doc(s) own code paths in this commit but their`);
+  console.error(`last-reviewed date is not today (${TODAY}):`);
+  console.error('');
+  for (const { docPath, lastReviewed } of stale) {
+    console.error(`  - ${docPath} — last-reviewed: ${lastReviewed ?? '(none)'}`);
+  }
+  console.error('');
+  console.error('Either:');
+  console.error('  1. Update each doc to reflect the code change, then bump');
+  console.error(`     its frontmatter \`last-reviewed: ${TODAY}\`, then re-stage.`);
+  console.error('  2. If the change genuinely doesn\'t affect the doc, bump');
+  console.error(`     last-reviewed: ${TODAY} on the doc anyway (you\'ve now`);
+  console.error('     verified it\'s still accurate post-change).');
+  console.error('  3. Legitimate WIP commit: `git commit --no-verify`.');
+  console.error('');
+  return 1;
+}
+
+const invokedDirectly = (() => {
+  try { return fileURLToPath(import.meta.url) === path.resolve(process.argv[1] || ''); }
+  catch { return false; }
+})();
+if (invokedDirectly) {
+  main().then(code => process.exit(code)).catch(err => {
+    console.error(`check-docs-freshness failed: ${err.message}`);
+    if (process.env.DEBUG) console.error(err.stack);
+    process.exit(2);
+  });
+}
+
+// Test-only exports.
+export { readFrontmatterField, main as runCheckDocsFreshness };

--- a/scripts/match-docs.mjs
+++ b/scripts/match-docs.mjs
@@ -1,0 +1,582 @@
+#!/usr/bin/env node
+// match-docs.mjs — route a git diff to the docs that should be updated.
+//
+// Usage:
+//   node scripts/match-docs.mjs <base-ref> [--out-dir <path>]
+//
+// Examples:
+//   node scripts/match-docs.mjs main           # diff main...HEAD
+//   node scripts/match-docs.mjs HEAD~1         # last commit
+//   node scripts/match-docs.mjs origin/master  # diff origin/master...HEAD
+//   node scripts/match-docs.mjs main --out-dir ./out  # pinned output location
+//
+// Reads:
+//   docs/_meta/doc-ownership.yml
+// Writes:
+//   <out-dir>/affected-docs.txt          newline-separated doc filenames
+//   <out-dir>/match-summary.md           human-readable summary
+//
+// Default <out-dir> is <tmpdir>; the filenames include a short hash of CWD
+// so parallel runs (monorepo, worktrees, CI matrix) don't clobber each other.
+// Pass --out-dir to pin the location (useful in CI when downstream steps
+// need to read the files at a known path).
+//
+// Zero runtime deps — uses only Node built-ins. The doc-ownership.yml parser
+// handles the specific subset of YAML this file uses (docs: / paths: /
+// concepts: lists). It is NOT a general YAML parser.
+
+import { execSync } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import os from 'node:os';
+
+const CWD = process.cwd();
+const OWNERSHIP_PATH = path.join(CWD, 'docs', '_meta', 'doc-ownership.yml');
+
+function die(msg, code = 1) {
+  console.error(msg);
+  process.exit(code);
+}
+
+// ---- YAML subset parser --------------------------------------------------
+//
+// Handles exactly the shape doc-ownership.yml uses:
+//
+//   docs:
+//     <slug>:
+//       paths:
+//         - 'glob'
+//         - "glob"
+//         - glob
+//       concepts:
+//         - 'string'
+//       db_objects:                # opt-in, used to route SQL migration diffs
+//         - table: places
+//         - function: find_nearest_place
+//         - rls: "all tables"
+//
+// Indentation is detected per-file (2-space, 4-space, etc.) — not hardcoded.
+// Tabs are normalized to 2 spaces. UTF-8 BOM is stripped.
+//
+// Returns: {
+//   docs: { <slug>: {
+//     paths: string[],
+//     concepts: string[],
+//     db_objects: Array<{table?:string, function?:string, rls?:string}>,
+//   } },
+//   warnings: string[]
+// }
+// `warnings` is non-empty if the parser saw tokens it couldn't make sense of.
+
+function parseOwnershipYaml(text) {
+  if (text.charCodeAt(0) === 0xFEFF) text = text.slice(1);
+  text = text.replace(/\t/g, '  ');
+  const lines = text.split(/\r?\n/);
+  const warnings = [];
+
+  // Tokenize: [{ lineNo, indent, content }] for non-comment, non-blank lines.
+  const tokens = [];
+  for (let i = 0; i < lines.length; i++) {
+    const stripped = lines[i].replace(/#.*$/, '').replace(/\s+$/, '');
+    if (!stripped.trim()) continue;
+    const indent = stripped.length - stripped.trimStart().length;
+    tokens.push({ lineNo: i + 1, indent, content: stripped.trimStart() });
+  }
+
+  if (tokens.length === 0) return { docs: {}, warnings };
+
+  // Find the `docs:` block at indent 0.
+  const docsTok = tokens.find(t => t.indent === 0 && t.content === 'docs:');
+  if (!docsTok) {
+    warnings.push(`No top-level \`docs:\` key found.`);
+    return { docs: {}, warnings };
+  }
+
+  // Tokens inside the docs: block (until the next indent-0 line, if any).
+  const docsStart = tokens.indexOf(docsTok) + 1;
+  let docsEnd = tokens.length;
+  for (let i = docsStart; i < tokens.length; i++) {
+    if (tokens[i].indent === 0) { docsEnd = i; break; }
+  }
+  const inner = tokens.slice(docsStart, docsEnd);
+  if (inner.length === 0) return { docs: {}, warnings };
+
+  // Detect the indent unit (smallest non-zero indent inside the block).
+  // For a well-formed file, the first child of `docs:` is a doc slug at
+  // exactly one indent unit.
+  const unit = inner[0].indent;
+  if (unit <= 0) {
+    warnings.push(`Lines inside \`docs:\` block have indent ≤0 — file appears malformed.`);
+    return { docs: {}, warnings };
+  }
+
+  const result = {};
+  let currentSlug = null;
+  let currentList = null; // 'paths' | 'concepts'
+
+  for (const tok of inner) {
+    const { lineNo, indent, content } = tok;
+    if (indent % unit !== 0) {
+      warnings.push(`Line ${lineNo}: indent ${indent} is not a multiple of detected unit ${unit}. Skipped.`);
+      continue;
+    }
+    const level = indent / unit; // 1=slug, 2=paths/concepts key, 3=list item
+
+    if (level === 1 && content.endsWith(':')) {
+      currentSlug = content.slice(0, -1).trim();
+      result[currentSlug] = { paths: [], concepts: [], db_objects: [] };
+      currentList = null;
+    } else if (level === 2 && content.endsWith(':') && currentSlug) {
+      const key = content.slice(0, -1).trim();
+      currentList = (key === 'paths' || key === 'concepts' || key === 'db_objects') ? key : null;
+      if (currentList === null) {
+        warnings.push(`Line ${lineNo}: unknown key "${key}" under doc "${currentSlug}" (expected "paths", "concepts", or "db_objects").`);
+      }
+    } else if (level === 3 && currentSlug && currentList && content.startsWith('-')) {
+      const itemText = content.slice(1).trim();
+      if (currentList === 'db_objects') {
+        // Each item is `<key>: <value>`. Allowed keys: table, function, rls.
+        const m = itemText.match(/^(table|function|rls)\s*:\s*(.+)$/);
+        if (!m) {
+          warnings.push(`Line ${lineNo}: db_objects item "${itemText}" — expected \`table: <name>\`, \`function: <name>\`, or \`rls: <value>\`.`);
+          continue;
+        }
+        let value = m[2].trim();
+        if (
+          (value.startsWith("'") && value.endsWith("'")) ||
+          (value.startsWith('"') && value.endsWith('"'))
+        ) {
+          value = value.slice(1, -1);
+        }
+        result[currentSlug].db_objects.push({ [m[1]]: value });
+      } else {
+        let value = itemText;
+        if (
+          (value.startsWith("'") && value.endsWith("'")) ||
+          (value.startsWith('"') && value.endsWith('"'))
+        ) {
+          value = value.slice(1, -1);
+        }
+        if (value) result[currentSlug][currentList].push(value);
+      }
+    } else {
+      warnings.push(`Line ${lineNo}: could not interpret "${content}" at level ${level}. Skipped.`);
+    }
+  }
+
+  return { docs: result, warnings };
+}
+
+// ---- SQL migration parsing ----------------------------------------------
+//
+// Extract db objects (tables, functions, policy-changed flag) referenced by
+// CREATE/ALTER/DROP statements in a Postgres migration. Used to route SQL
+// diffs to the docs that own those db objects.
+//
+// Comments (`-- line` and `/* block */`) are stripped before scanning so DDL
+// in commentary is ignored. DDL inside string literals is NOT stripped — that
+// would require a real parser and is a rarer case.
+//
+// Optional schema prefix `<schema>.` before identifiers is accepted and
+// discarded; we match the bare object name.
+
+function extractDbObjectsFromMigration(sqlContent) {
+  const cleaned = sqlContent
+    .replace(/--[^\n]*/g, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '');
+
+  const tables = new Set();
+  const functions = new Set();
+  let hasPolicyChange = false;
+
+  const createTable = /\bCREATE\s+(?:OR\s+REPLACE\s+)?TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(?:["']?\w+["']?\.)?["']?(\w+)["']?/gi;
+  const alterTable = /\bALTER\s+TABLE\s+(?:IF\s+EXISTS\s+)?(?:["']?\w+["']?\.)?["']?(\w+)["']?/gi;
+  const dropTable = /\bDROP\s+TABLE\s+(?:IF\s+EXISTS\s+)?(?:["']?\w+["']?\.)?["']?(\w+)["']?/gi;
+  const createFunction = /\bCREATE\s+(?:OR\s+REPLACE\s+)?FUNCTION\s+(?:["']?\w+["']?\.)?["']?(\w+)["']?/gi;
+  const createPolicy = /\bCREATE\s+POLICY\b/gi;
+  const alterPolicy = /\bALTER\s+POLICY\b/gi;
+  const dropPolicy = /\bDROP\s+POLICY\b/gi;
+
+  for (const pattern of [createTable, alterTable, dropTable]) {
+    let m;
+    while ((m = pattern.exec(cleaned)) !== null) tables.add(m[1]);
+  }
+  let fm;
+  while ((fm = createFunction.exec(cleaned)) !== null) functions.add(fm[1]);
+  if (createPolicy.test(cleaned) || alterPolicy.test(cleaned) || dropPolicy.test(cleaned)) {
+    hasPolicyChange = true;
+  }
+
+  return { tables: [...tables], functions: [...functions], hasPolicyChange };
+}
+
+// ---- Routing helpers (composable) ---------------------------------------
+//
+// These are extracted from main() so other tools (e.g. check-docs-freshness)
+// can compose the same routing logic without duplicating it.
+
+function compileOwnership(ownership) {
+  return Object.entries(ownership).map(([doc, spec]) => ({
+    doc,
+    pathRegexes: spec.paths.map(p => ({ glob: p, re: globToRegExp(p) })),
+    concepts: spec.concepts || [],
+    dbObjects: spec.db_objects || [],
+  }));
+}
+
+function matchPathToDocs(file, compiled) {
+  const out = [];
+  for (const { doc, pathRegexes } of compiled) {
+    for (const { re } of pathRegexes) {
+      if (re.test(file)) {
+        out.push(doc);
+        break;
+      }
+    }
+  }
+  return out;
+}
+
+// Returns Map<doc, hits[]> where each hit string is "table:foo" /
+// "function:bar" / "rls:all tables" — used both for routing and for the
+// human-readable match summary.
+function matchSqlToDocs(sqlText, compiled) {
+  const { tables, functions, hasPolicyChange } = extractDbObjectsFromMigration(sqlText);
+  const hitsByDoc = new Map();
+  for (const { doc, dbObjects } of compiled) {
+    if (!dbObjects.length) continue;
+    const hits = [];
+    for (const obj of dbObjects) {
+      if (obj.table && tables.includes(obj.table)) hits.push(`table:${obj.table}`);
+      if (obj.function && functions.includes(obj.function)) hits.push(`function:${obj.function}`);
+      if (obj.rls === 'all tables' && hasPolicyChange) hits.push('rls:all tables');
+    }
+    if (hits.length) hitsByDoc.set(doc, hits);
+  }
+  return hitsByDoc;
+}
+
+// Read and parse doc-ownership.yml from <cwd>/docs/_meta/doc-ownership.yml
+// (or a custom path). Returns { ownership, warnings }. Throws if the file
+// is missing or contains zero valid doc entries.
+async function loadOwnership(ownershipPath = OWNERSHIP_PATH) {
+  let text;
+  try {
+    text = await fs.readFile(ownershipPath, 'utf8');
+  } catch (err) {
+    throw new Error(`Could not read ${ownershipPath}: ${err.message}`);
+  }
+  const { docs: ownership, warnings } = parseOwnershipYaml(text);
+  if (Object.keys(ownership).length === 0) {
+    const hasContent = text.replace(/#.*$/gm, '').replace(/^\s*$/gm, '').trim().length > 0;
+    if (hasContent) {
+      throw new Error(`${ownershipPath} has content but the parser found zero docs. Most common cause: inconsistent indentation.`);
+    }
+    throw new Error(`${ownershipPath} has no docs entries.`);
+  }
+  return { ownership, warnings };
+}
+
+// ---- Glob → RegExp -------------------------------------------------------
+//
+// Supports: **, *, ?, literal strings, file extensions. Does not support
+// brace expansion ({a,b}) or character classes.
+
+function globToRegExp(glob) {
+  // Normalize Windows-style backslashes to forward slashes.
+  const normalized = glob.replace(/\\/g, '/');
+  let re = '';
+  for (let i = 0; i < normalized.length; i++) {
+    const c = normalized[i];
+    const next = normalized[i + 1];
+    if (c === '*' && next === '*') {
+      re += '.*';
+      i++;
+      // Skip the slash after ** if present (so 'src/**/foo' matches 'src/foo' too).
+      if (normalized[i + 1] === '/') i++;
+    } else if (c === '*') {
+      re += '[^/]*';
+    } else if (c === '?') {
+      re += '.';
+    } else if ('.+^$|()[]{}\\'.includes(c)) {
+      re += '\\' + c;
+    } else {
+      re += c;
+    }
+  }
+  return new RegExp('^' + re + '$');
+}
+
+// ---- Git diff ------------------------------------------------------------
+
+function getChangedFiles(baseRef) {
+  // Try 3-dot diff first (covers the "common ancestor" case for feature branches).
+  // Fall back to 2-dot if 3-dot fails (e.g. baseRef is a single commit like HEAD~1).
+  const tryCommands = [
+    ['diff', '--name-only', `${baseRef}...HEAD`],
+    ['diff', '--name-only', baseRef],
+  ];
+  for (const args of tryCommands) {
+    try {
+      const out = execSync(`git ${args.join(' ')}`, { cwd: CWD, stdio: ['ignore', 'pipe', 'pipe'] }).toString();
+      return out.split('\n').map(s => s.trim()).filter(Boolean);
+    } catch {
+      // try next
+    }
+  }
+  die(`Could not run \`git diff\` against base ref "${baseRef}". Is this a git repo, and is the ref valid?`);
+}
+
+// ---- Concept matching (optional) -----------------------------------------
+
+async function fileContains(filePath, needles) {
+  if (!needles.length) return [];
+  const abs = path.join(CWD, filePath);
+  try {
+    const content = await fs.readFile(abs, 'utf8');
+    return needles.filter(n => content.includes(n));
+  } catch {
+    return [];
+  }
+}
+
+// ---- Main ----------------------------------------------------------------
+
+function parseArgs(argv) {
+  const args = { baseRef: null, outDir: null };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--out-dir') args.outDir = argv[++i];
+    else if (!a.startsWith('--') && args.baseRef === null) args.baseRef = a;
+    else die(`Unknown argument: ${a}\nUsage: node scripts/match-docs.mjs <base-ref> [--out-dir <path>]`);
+  }
+  return args;
+}
+
+function resolveOutPaths(outDir) {
+  if (outDir) {
+    const abs = path.resolve(outDir);
+    return {
+      affected: path.join(abs, 'affected-docs.txt'),
+      summary: path.join(abs, 'match-summary.md'),
+    };
+  }
+  // Default: tmpdir + short CWD hash so parallel runs don't clobber.
+  const cwdHash = createHash('sha1').update(CWD).digest('hex').slice(0, 8);
+  return {
+    affected: path.join(os.tmpdir(), `affected-docs-${cwdHash}.txt`),
+    summary: path.join(os.tmpdir(), `match-summary-${cwdHash}.md`),
+  };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const baseRef = args.baseRef;
+  if (!baseRef) {
+    die(`Usage: node scripts/match-docs.mjs <base-ref> [--out-dir <path>]\nExample: node scripts/match-docs.mjs main`);
+  }
+  const { affected: AFFECTED_PATH, summary: SUMMARY_PATH } = resolveOutPaths(args.outDir);
+  if (args.outDir) await fs.mkdir(path.dirname(AFFECTED_PATH), { recursive: true });
+
+  let ownershipText;
+  try {
+    ownershipText = await fs.readFile(OWNERSHIP_PATH, 'utf8');
+  } catch (err) {
+    die(`Could not read ${OWNERSHIP_PATH}: ${err.message}\n\nDid you run \`npx wts-ai-docs init\` to bootstrap the vault?`);
+  }
+
+  const { docs: ownership, warnings } = parseOwnershipYaml(ownershipText);
+  if (warnings.length) {
+    console.error(`!! doc-ownership.yml parse warnings:`);
+    for (const w of warnings) console.error(`   ${w}`);
+    console.error('');
+  }
+  if (Object.keys(ownership).length === 0) {
+    const hasContent = ownershipText.replace(/#.*$/gm, '').replace(/^\s*$/gm, '').trim().length > 0;
+    if (hasContent) {
+      die(`${OWNERSHIP_PATH} has content but the parser found zero docs.\n\nMost common cause: inconsistent indentation. The parser auto-detects the indent unit (2-space, 4-space, ...) but it must be consistent within the file. See parse warnings above and the example in templates/doc-ownership.yml.\n\nFailing closed rather than producing wrong routing output.`);
+    }
+    die(`${OWNERSHIP_PATH} has no docs entries. Add at least one doc with paths: before running this.`);
+  }
+
+  // Pre-compile regexes.
+  const compiled = compileOwnership(ownership);
+
+  // SQL routing is opt-in: only active when at least one doc declares
+  // `db_objects:`. Avoids the cost of reading every .sql diff on projects
+  // that don't care.
+  const sqlRoutingEnabled = compiled.some(c => c.dbObjects.length > 0);
+
+  const changedFiles = getChangedFiles(baseRef);
+  if (changedFiles.length === 0) {
+    console.log(`No files changed against ${baseRef}.`);
+    await fs.writeFile(AFFECTED_PATH, '', 'utf8');
+    await fs.writeFile(SUMMARY_PATH, `# Doc Routing Summary\n\nNo files changed against \`${baseRef}\`.\n`, 'utf8');
+    return;
+  }
+
+  const matchesByDoc = {};         // doc -> { paths, concepts, dbObjects: Map<file, string[]> }
+  const fileToMatches = {};        // file -> Set<doc>
+  for (const { doc } of compiled) {
+    matchesByDoc[doc] = { paths: new Set(), concepts: new Map(), dbObjects: new Map() };
+  }
+
+  // Path matches.
+  for (const file of changedFiles) {
+    for (const doc of matchPathToDocs(file, compiled)) {
+      matchesByDoc[doc].paths.add(file);
+      if (!fileToMatches[file]) fileToMatches[file] = new Set();
+      fileToMatches[file].add(doc);
+    }
+  }
+
+  // Concept matches (only on files that exist on disk after the diff — i.e. not deleted).
+  for (const file of changedFiles) {
+    for (const { doc, concepts } of compiled) {
+      if (!concepts.length) continue;
+      const hits = await fileContains(file, concepts);
+      if (hits.length) {
+        matchesByDoc[doc].concepts.set(file, hits);
+        if (!fileToMatches[file]) fileToMatches[file] = new Set();
+        fileToMatches[file].add(doc);
+      }
+    }
+  }
+
+  // SQL migration routing — parse changed *.sql files and route them to docs
+  // that claim the db objects (tables, functions, policies) the migration
+  // touches. Opt-in: only fires when at least one doc declares db_objects:.
+  if (sqlRoutingEnabled) {
+    for (const file of changedFiles) {
+      if (!file.endsWith('.sql')) continue;
+      let sql;
+      try {
+        sql = await fs.readFile(path.join(CWD, file), 'utf8');
+      } catch {
+        continue; // deleted in diff, or unreadable — skip silently
+      }
+      for (const [doc, hits] of matchSqlToDocs(sql, compiled)) {
+        matchesByDoc[doc].dbObjects.set(file, hits);
+        if (!fileToMatches[file]) fileToMatches[file] = new Set();
+        fileToMatches[file].add(doc);
+      }
+    }
+  }
+
+  const unmatched = changedFiles.filter(f => !fileToMatches[f]);
+  const affectedDocs = Object.entries(matchesByDoc)
+    .filter(([, m]) => m.paths.size > 0 || m.concepts.size > 0 || m.dbObjects.size > 0)
+    .map(([doc]) => doc)
+    .sort();
+
+  // affected-docs.txt — one filename per line (e.g. "auth.md")
+  await fs.writeFile(
+    AFFECTED_PATH,
+    affectedDocs.map(d => `${d}.md`).join('\n') + (affectedDocs.length ? '\n' : ''),
+    'utf8',
+  );
+
+  // match-summary.md — human-readable.
+  const lines = [];
+  lines.push(`# Doc Routing Summary`);
+  lines.push('');
+  lines.push(`Diff base: \`${baseRef}\``);
+  lines.push(`Changed files: ${changedFiles.length}`);
+  lines.push(`Affected docs: ${affectedDocs.length}`);
+  lines.push(`Unmatched files: ${unmatched.length}`);
+  if (warnings.length) {
+    lines.push(`Parse warnings: ${warnings.length}`);
+  }
+  lines.push('');
+
+  if (warnings.length) {
+    lines.push(`## ⚠ doc-ownership.yml parse warnings`);
+    lines.push('');
+    lines.push(`> The parser saw lines it couldn't interpret. Fix these — partial parsing means some docs may be silently skipped.`);
+    lines.push('');
+    for (const w of warnings) lines.push(`- ${w}`);
+    lines.push('');
+  }
+
+  if (affectedDocs.length) {
+    lines.push(`## Affected docs`);
+    lines.push('');
+    for (const doc of affectedDocs) {
+      const m = matchesByDoc[doc];
+      lines.push(`### \`docs/${doc}.md\``);
+      if (m.paths.size) {
+        lines.push('');
+        lines.push(`**Path matches** (${m.paths.size}):`);
+        for (const f of [...m.paths].sort()) lines.push(`- \`${f}\``);
+      }
+      if (m.concepts.size) {
+        lines.push('');
+        lines.push(`**Concept matches** (${m.concepts.size}):`);
+        for (const [f, hits] of [...m.concepts.entries()].sort()) {
+          lines.push(`- \`${f}\` — ${hits.map(h => '`' + h + '`').join(', ')}`);
+        }
+      }
+      if (m.dbObjects.size) {
+        lines.push('');
+        lines.push(`**DB object matches** (${m.dbObjects.size}):`);
+        for (const [f, hits] of [...m.dbObjects.entries()].sort()) {
+          lines.push(`- \`${f}\` — ${hits.map(h => '`' + h + '`').join(', ')}`);
+        }
+      }
+      lines.push('');
+    }
+  }
+
+  if (unmatched.length) {
+    lines.push(`## Unmatched files`);
+    lines.push('');
+    lines.push(`> These files changed but no doc claims them. Either add them to a doc's \`paths:\` in \`docs/_meta/doc-ownership.yml\` and re-run, or confirm they legitimately have no doc owner.`);
+    lines.push('');
+    for (const f of unmatched.sort()) lines.push(`- \`${f}\``);
+    lines.push('');
+  }
+
+  await fs.writeFile(SUMMARY_PATH, lines.join('\n'), 'utf8');
+
+  // Console report.
+  console.log(`Diff base:        ${baseRef}`);
+  console.log(`Changed files:    ${changedFiles.length}`);
+  console.log(`Affected docs:    ${affectedDocs.length}${affectedDocs.length ? ' (' + affectedDocs.join(', ') + ')' : ''}`);
+  console.log(`Unmatched files:  ${unmatched.length}`);
+  console.log('');
+  console.log(`Wrote: ${AFFECTED_PATH}`);
+  console.log(`Wrote: ${SUMMARY_PATH}`);
+  if (unmatched.length) {
+    console.log('');
+    console.log(`!! ${unmatched.length} unmatched file(s). See match-summary.md and resolve before merging.`);
+  }
+
+  // Exit non-zero on parse warnings so CI catches partial parses.
+  if (warnings.length) process.exit(2);
+}
+
+const invokedDirectly = (() => {
+  try { return fileURLToPath(import.meta.url) === path.resolve(process.argv[1] || ''); }
+  catch { return false; }
+})();
+if (invokedDirectly) {
+  main().catch(err => {
+    console.error(`match-docs failed: ${err.message}`);
+    if (process.env.DEBUG) console.error(err.stack);
+    process.exit(1);
+  });
+}
+
+// Exports — used by tests and by other tools that compose this routing logic
+// (e.g. scripts/check-docs-freshness.mjs).
+export {
+  parseOwnershipYaml,
+  globToRegExp,
+  extractDbObjectsFromMigration,
+  compileOwnership,
+  matchPathToDocs,
+  matchSqlToDocs,
+  loadOwnership,
+};

--- a/scripts/vault-doctor.mjs
+++ b/scripts/vault-doctor.mjs
@@ -1,0 +1,650 @@
+#!/usr/bin/env node
+// vault-doctor.mjs — lint a wts-ai-docs vault for structural and freshness issues.
+//
+// Usage:
+//   node scripts/vault-doctor.mjs [--root <path>] [--max-age <days>] [--json]
+//   node scripts/vault-doctor.mjs --help
+//
+// Exit codes:
+//   0 — no violations
+//   1 — at least one violation
+//   2 — fatal error (vault not found, bad args, etc.)
+//
+// Checks:
+//   1. Frontmatter shape — every .md under docs/ (except _archive/) has the
+//      required keys: title, domain, status, last-reviewed.
+//   2. last-reviewed staleness — older than --max-age days (default 60).
+//   3. "What's in / What's NOT" callout — required on every top-level
+//      docs/<slug>.md domain doc (not under _meta/, _archive/, _cheatsheets/,
+//      and not underscore-prefixed like _index.md / _backlog.md).
+//   4. Wikilinks resolve — every [[target]] and [[target#anchor]] resolves to
+//      an existing doc and (if anchor) to an actual heading in that doc.
+//   5. Domain stem match — for top-level domain docs, frontmatter `domain:`
+//      equals the filename stem.
+//   6. Doc length — domain docs longer than --max-doc-lines (default 600)
+//      cost the agent context budget. The warning triggers a "split or extract
+//      a cheatsheet" conversation before the doc becomes unreadable.
+//
+// Deferred to a later milestone:
+//   * doc-ownership.yml cite-against-paths.
+//
+// Zero runtime deps — Node built-ins only. The YAML frontmatter parser handles
+// only the constrained shape vault docs use (string values, date values, simple
+// `- item` lists). It is NOT a general YAML parser.
+
+import { promises as fs } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const DEFAULT_MAX_AGE_DAYS = 60;
+const DEFAULT_MAX_DOC_LINES = 600;
+
+// ---- CLI ----------------------------------------------------------------
+
+const HELP = `vault-doctor — lint a wts-ai-docs vault.
+
+USAGE
+  node scripts/vault-doctor.mjs [--root <path>] [--max-age <days>]
+                                [--max-doc-lines <n>] [--json]
+  node scripts/vault-doctor.mjs --help
+
+OPTIONS
+  --root <path>           Vault root (default: ./docs relative to cwd).
+  --max-age <days>        Default freshness threshold (default: ${DEFAULT_MAX_AGE_DAYS}).
+                          Per-doc override: frontmatter \`max-age: N\`.
+  --max-doc-lines <n>     Warn when a domain doc exceeds N lines (default: ${DEFAULT_MAX_DOC_LINES}).
+                          A long doc burns agent context budget; split or
+                          extract a cheatsheet. Per-doc override: frontmatter
+                          \`max-doc-lines: N\` (set to 0 to disable for that doc).
+  --json                  Emit machine-readable JSON instead of human text.
+  --help, -h              Show this help.
+
+ESCAPE HATCHES (frontmatter, per-doc)
+  vault-doctor: skip                              # skip ALL checks on this doc
+  vault-doctor-skip-checks: [stale, wikilink]     # skip a subset
+  max-age: 30                                     # override --max-age for this doc
+  max-doc-lines: 800                              # override --max-doc-lines for this doc
+
+INLINE ESCAPE HATCH (in doc body)
+  See [[business#planned-section]] <!-- vault-doctor: ignore -->
+
+EXIT CODES
+  0   no violations
+  1   at least one violation
+  2   fatal (e.g. vault root missing)
+`;
+
+function parseArgs(argv) {
+  const args = {
+    root: null,
+    maxAge: DEFAULT_MAX_AGE_DAYS,
+    maxDocLines: DEFAULT_MAX_DOC_LINES,
+    json: false,
+    help: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--help' || a === '-h') args.help = true;
+    else if (a === '--json') args.json = true;
+    else if (a === '--root') args.root = argv[++i];
+    else if (a === '--max-age') {
+      const n = parseInt(argv[++i], 10);
+      if (!Number.isFinite(n) || n < 0) die(`--max-age must be a non-negative integer, got "${argv[i]}".`, 2);
+      args.maxAge = n;
+    } else if (a === '--max-doc-lines') {
+      const n = parseInt(argv[++i], 10);
+      if (!Number.isFinite(n) || n < 0) die(`--max-doc-lines must be a non-negative integer, got "${argv[i]}".`, 2);
+      args.maxDocLines = n;
+    } else {
+      die(`Unknown argument: ${a}\nRun --help for usage.`, 2);
+    }
+  }
+  return args;
+}
+
+function die(msg, code = 2) {
+  console.error(msg);
+  process.exit(code);
+}
+
+// ---- YAML frontmatter parser (constrained subset) ----------------------
+//
+// Handles: --- delimiters, `key: value` strings (quoted or not), date values
+// (YYYY-MM-DD as string), and `- item` lists under a key. Rejects anything
+// else (anchors, nested objects, multi-line scalars) with a useful error.
+
+function parseFrontmatter(text) {
+  // Strip UTF-8 BOM.
+  if (text.charCodeAt(0) === 0xFEFF) text = text.slice(1);
+  // Normalize line endings.
+  const lines = text.split(/\r?\n/);
+
+  // Frontmatter must start at line 1 with `---`.
+  if (lines[0] !== '---') return { found: false };
+
+  // Find closing `---`.
+  let endIdx = -1;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i] === '---') { endIdx = i; break; }
+  }
+  if (endIdx === -1) return { found: true, error: 'unterminated frontmatter (no closing `---`)' };
+
+  const fm = {};
+  let currentListKey = null;
+
+  for (let i = 1; i < endIdx; i++) {
+    const raw = lines[i];
+    const stripped = raw.replace(/\s+$/, '');
+    if (!stripped.trim()) { currentListKey = null; continue; }
+    if (stripped.trimStart().startsWith('#')) continue; // comment
+
+    const indent = stripped.length - stripped.trimStart().length;
+
+    // List item under the previous key.
+    if (currentListKey && indent > 0 && stripped.trimStart().startsWith('-')) {
+      const value = stripped.trimStart().slice(1).trim();
+      const unquoted = unquote(value);
+      fm[currentListKey].push(unquoted);
+      continue;
+    }
+
+    // key: value or key:
+    if (indent !== 0) {
+      return { found: true, error: `line ${i + 1}: unexpected indent (parser supports flat key:value and one-level lists only)` };
+    }
+    const m = stripped.match(/^([A-Za-z][\w-]*):\s*(.*)$/);
+    if (!m) {
+      return { found: true, error: `line ${i + 1}: could not parse "${stripped}" — expected \`key: value\` or \`key:\`` };
+    }
+    const key = m[1];
+    const valueRaw = m[2];
+    if (valueRaw === '') {
+      // Begin a block list (or a sub-block — but we don't support sub-blocks).
+      fm[key] = [];
+      currentListKey = key;
+    } else if (valueRaw.startsWith('[') && valueRaw.endsWith(']')) {
+      // Inline list: `key: [a, b, "c"]`. Items are split on commas and unquoted.
+      // Commas inside quoted values aren't supported (parser stays simple).
+      const inner = valueRaw.slice(1, -1).trim();
+      fm[key] = inner === ''
+        ? []
+        : inner.split(',').map(s => unquote(s.trim()));
+      currentListKey = null;
+    } else {
+      fm[key] = unquote(valueRaw);
+      currentListKey = null;
+    }
+  }
+
+  return { found: true, data: fm, bodyStartLine: endIdx + 1 };
+}
+
+function unquote(s) {
+  if (
+    (s.startsWith("'") && s.endsWith("'")) ||
+    (s.startsWith('"') && s.endsWith('"'))
+  ) {
+    return s.slice(1, -1);
+  }
+  return s;
+}
+
+// ---- File discovery -----------------------------------------------------
+
+async function walk(dir, excludeDirs) {
+  const out = [];
+  async function recurse(d) {
+    let entries;
+    try {
+      entries = await fs.readdir(d, { withFileTypes: true });
+    } catch (err) {
+      throw new Error(`cannot read directory ${d}: ${err.message}`);
+    }
+    for (const ent of entries) {
+      const full = path.join(d, ent.name);
+      if (ent.isDirectory()) {
+        if (excludeDirs.has(ent.name)) continue;
+        await recurse(full);
+      } else if (ent.isFile() && ent.name.endsWith('.md')) {
+        out.push(full);
+      }
+    }
+  }
+  await recurse(dir);
+  return out;
+}
+
+// ---- Doc classification -------------------------------------------------
+//
+// Given a path relative to vault root (e.g. "auth.md", "_meta/foo.md",
+// "session-review/2026-04-14.md"), return a classification:
+//   - 'domain'      : top-level docs/<slug>.md — full checks (incl. callout + stem)
+//   - 'meta'        : docs/_meta/*.md — frontmatter + wikilinks only
+//   - 'cheatsheet'  : docs/_cheatsheets/*.md — frontmatter + wikilinks only
+//   - 'index-like'  : docs/_index.md, docs/_backlog.md — frontmatter + wikilinks only
+//   - 'other'       : subdirs not part of the vault convention (e.g. session-review/,
+//                     superpowers/, adr/) — skipped entirely. README.md is also skipped.
+
+function classify(relPosix) {
+  const segments = relPosix.split('/');
+  if (segments[0] === '_archive') return 'skip';
+  if (segments[0] === '_meta') return 'meta';
+  if (segments[0] === '_cheatsheets') return 'cheatsheet';
+  if (segments.length === 1) {
+    const name = segments[0];
+    if (name === '_index.md' || name === '_backlog.md') return 'index-like';
+    if (name.toLowerCase() === 'readme.md') return 'skip';
+    if (name.startsWith('_')) return 'index-like';
+    return 'domain';
+  }
+  // Anything in a non-convention subdir.
+  return 'skip';
+}
+
+// ---- Checks -------------------------------------------------------------
+
+const REQUIRED_FRONTMATTER_KEYS = ['title', 'domain', 'status', 'last-reviewed'];
+
+function checkFrontmatter(doc) {
+  const violations = [];
+  if (!doc.frontmatter.found) {
+    violations.push({ check: 'frontmatter', detail: 'missing frontmatter block (file must start with `---`)' });
+    return violations;
+  }
+  if (doc.frontmatter.error) {
+    violations.push({ check: 'frontmatter', detail: `parse error: ${doc.frontmatter.error}` });
+    return violations;
+  }
+  for (const key of REQUIRED_FRONTMATTER_KEYS) {
+    if (!(key in doc.frontmatter.data)) {
+      violations.push({ check: 'frontmatter', detail: `missing required key \`${key}\`` });
+    }
+  }
+  return violations;
+}
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+function checkStaleness(doc, defaultMaxAge, today) {
+  if (!doc.frontmatter.data) return [];
+  const value = doc.frontmatter.data['last-reviewed'];
+  if (!value) return []; // already reported by frontmatter check
+  if (!DATE_RE.test(value)) {
+    return [{ check: 'stale', detail: `last-reviewed \`${value}\` is not a valid YYYY-MM-DD date` }];
+  }
+  // Per-doc max-age overrides the CLI default. Useful when one runbook needs
+  // tighter freshness than the rest of the vault (or looser).
+  const docMaxAge = doc.frontmatter.data['max-age'];
+  let maxAge = defaultMaxAge;
+  if (docMaxAge !== undefined) {
+    const n = parseInt(docMaxAge, 10);
+    if (!Number.isFinite(n) || n < 0) {
+      return [{ check: 'stale', detail: `frontmatter max-age \`${docMaxAge}\` is not a non-negative integer` }];
+    }
+    maxAge = n;
+  }
+  const ageMs = today.getTime() - Date.parse(value + 'T00:00:00Z');
+  const ageDays = Math.floor(ageMs / (1000 * 60 * 60 * 24));
+  if (ageDays > maxAge) {
+    return [{ check: 'stale', detail: `last-reviewed ${value} is ${ageDays} days old (max ${maxAge})` }];
+  }
+  return [];
+}
+
+const CALLOUT_IN_RE = /What['’]s in this doc:/;
+const CALLOUT_NOT_RE = /What['’]s NOT:/;
+
+function checkCallout(doc) {
+  // Scan the first ~40 body lines for both phrases inside a blockquote.
+  const body = doc.body.split(/\r?\n/).slice(0, 60).join('\n');
+  if (!CALLOUT_IN_RE.test(body)) {
+    return [{ check: 'callout', detail: 'missing "What’s in this doc:" line near top of doc' }];
+  }
+  if (!CALLOUT_NOT_RE.test(body)) {
+    return [{ check: 'callout', detail: 'missing "What’s NOT:" line near top of doc' }];
+  }
+  return [];
+}
+
+function checkDomainStem(doc) {
+  if (!doc.frontmatter.data) return [];
+  const domain = doc.frontmatter.data['domain'];
+  if (!domain) return [];
+  const stem = path.basename(doc.relPath, '.md');
+  if (domain !== stem) {
+    return [{ check: 'domain-stem', detail: `frontmatter domain \`${domain}\` does not match filename stem \`${stem}\`` }];
+  }
+  return [];
+}
+
+// Doc length is a context-efficiency check, not a hallucination check. A
+// 600+ line domain doc forces the agent to load lots of mostly-irrelevant
+// content. The fix is usually one of: (a) split into two narrower docs,
+// (b) extract a cheatsheet for the highest-frequency lookup, or
+// (c) move stale sections to `_archive/`. Per-doc override via frontmatter
+// `max-doc-lines: N` (use 0 to disable for that doc).
+function checkDocLength(doc, defaultMax) {
+  const docMax = doc.frontmatter.data?.['max-doc-lines'];
+  let max = defaultMax;
+  if (docMax !== undefined) {
+    const n = parseInt(docMax, 10);
+    if (!Number.isFinite(n) || n < 0) {
+      return [{ check: 'length', detail: `frontmatter max-doc-lines \`${docMax}\` is not a non-negative integer` }];
+    }
+    max = n;
+  }
+  if (max === 0) return []; // explicit opt-out per-doc
+  const lineCount = doc.text.split(/\r?\n/).length;
+  if (lineCount > max) {
+    return [{
+      check: 'length',
+      detail: `${lineCount} lines exceeds limit ${max} — split, extract a cheatsheet, or archive stale sections`,
+    }];
+  }
+  return [];
+}
+
+// GitHub-style heading slug: lowercase, drop most punctuation, EACH whitespace
+// char → one hyphen (no collapsing — that's how GitHub renders "X & Y" as
+// `x--y`). Tested against real headings like:
+//   "What's NOT:"                 → whats-not
+//   "Known Quirks & Gotchas"      → known-quirks--gotchas
+//   "Next.js version"             → nextjs-version
+function slugifyHeading(h) {
+  return h
+    .toLowerCase()
+    .replace(/[’']/g, '')              // smart and dumb apostrophes
+    .replace(/[^\w\sÀ-ɏ-]/g, '')  // drop punctuation but keep Latin extended
+    .replace(/^\s+|\s+$/g, '')         // trim only — don't collapse interior whitespace
+    .replace(/\s/g, '-');              // each space → one hyphen (matches GitHub)
+}
+
+function extractHeadings(body) {
+  const slugs = new Set();
+  const seen = {};
+  for (const line of body.split(/\r?\n/)) {
+    const m = line.match(/^#{1,6}\s+(.+?)\s*#*\s*$/);
+    if (!m) continue;
+    let slug = slugifyHeading(m[1]);
+    if (slug in seen) {
+      seen[slug]++;
+      slug = `${slug}-${seen[slug]}`;
+    } else {
+      seen[slug] = 0;
+    }
+    slugs.add(slug);
+  }
+  return slugs;
+}
+
+const WIKILINK_RE = /\[\[([^\]\|#]+?)(?:#([^\]\|]+?))?(?:\|[^\]]+)?\]\]/g;
+
+// Strip fenced (``` / ~~~) and inline-code (`...`) spans from body before
+// extracting wikilinks, so example syntax inside docs doesn't fire wikilink
+// resolution. Convention docs intentionally show `[[filename]]` in code blocks.
+function stripCode(body) {
+  const lines = body.split(/\r?\n/);
+  let inFence = false;
+  let fenceMarker = '';
+  const out = [];
+  for (const line of lines) {
+    const fence = line.match(/^\s*(```|~~~)/);
+    if (fence) {
+      if (!inFence) { inFence = true; fenceMarker = fence[1]; out.push(''); continue; }
+      if (line.includes(fenceMarker)) { inFence = false; fenceMarker = ''; out.push(''); continue; }
+    }
+    if (inFence) { out.push(''); continue; }
+    // Strip inline code spans.
+    out.push(line.replace(/`[^`]*`/g, ''));
+  }
+  return out.join('\n');
+}
+
+// Inline ignore marker — placed on the same line as a wikilink to suppress
+// just that wikilink's resolution check. Useful for known-broken links you
+// haven't fixed yet, or links pointing at planned-but-unwritten docs.
+const INLINE_IGNORE_RE = /<!--\s*vault-doctor:\s*ignore\s*-->/;
+
+function checkWikilinks(doc, docsByStem) {
+  const violations = [];
+  const seen = new Set();
+  const scannable = stripCode(doc.body);
+  // Iterate line-by-line so we can honor inline ignores adjacent to the link.
+  for (const line of scannable.split(/\r?\n/)) {
+    if (INLINE_IGNORE_RE.test(line)) continue;
+    for (const match of line.matchAll(WIKILINK_RE)) {
+      const target = match[1].trim();
+      const anchor = match[2] ? match[2].trim() : null;
+      const key = `${target}#${anchor || ''}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+
+      const targetDoc = docsByStem.get(target);
+      if (!targetDoc) {
+        violations.push({
+          check: 'wikilink',
+          detail: `[[${target}${anchor ? '#' + anchor : ''}]] — target file not found in vault`,
+        });
+        continue;
+      }
+      if (anchor) {
+        const anchorSlug = slugifyHeading(anchor);
+        if (!targetDoc.headings.has(anchorSlug)) {
+          violations.push({
+            check: 'wikilink',
+            detail: `[[${target}#${anchor}]] — anchor \`${anchorSlug}\` not found in ${targetDoc.relPath}`,
+          });
+        }
+      }
+    }
+  }
+  return violations;
+}
+
+// ---- Pipeline -----------------------------------------------------------
+
+async function loadDoc(absPath, rootAbs) {
+  const text = await fs.readFile(absPath, 'utf8');
+  const relPath = path.relative(rootAbs, absPath).split(path.sep).join('/');
+  const fm = parseFrontmatter(text);
+  // Body is everything after the frontmatter block (or the whole file if none).
+  let body = text;
+  if (fm.found && fm.bodyStartLine) {
+    body = text.split(/\r?\n/).slice(fm.bodyStartLine).join('\n');
+  }
+  return {
+    absPath,
+    relPath,
+    text,
+    frontmatter: fm,
+    body,
+    headings: extractHeadings(body),
+    klass: classify(relPath),
+  };
+}
+
+async function audit({ root, maxAge, maxDocLines }) {
+  const rootAbs = path.resolve(root);
+  let stat;
+  try {
+    stat = await fs.stat(rootAbs);
+  } catch {
+    die(`Vault root not found: ${rootAbs}`, 2);
+  }
+  if (!stat.isDirectory()) die(`Vault root is not a directory: ${rootAbs}`, 2);
+
+  const files = await walk(rootAbs, new Set(['_archive']));
+  const docs = await Promise.all(files.map(f => loadDoc(f, rootAbs)));
+
+  // Index by stem (filename without .md, relative path components joined with /).
+  // Wikilinks use bare stems like [[auth]] or [[vault-conventions]] (without path),
+  // so register by stem only. Last-wins is fine because vault filenames should be
+  // globally unique.
+  const docsByStem = new Map();
+  for (const d of docs) {
+    const stem = path.basename(d.relPath, '.md');
+    docsByStem.set(stem, d);
+  }
+
+  const today = new Date();
+  const report = []; // { relPath, klass, violations: [], skipped: bool }
+
+  for (const d of docs) {
+    if (d.klass === 'skip') continue;
+
+    // File-level escape hatches via frontmatter:
+    //   vault-doctor: skip                          # skip ALL checks
+    //   vault-doctor: skip-checks: [stale, callout] # skip a subset
+    // Both shapes are honored. `skip` short-circuits; the list form filters.
+    const vdValue = d.frontmatter.data?.['vault-doctor'];
+    const vdSkipChecks = d.frontmatter.data?.['vault-doctor-skip-checks'];
+    if (vdValue === 'skip') {
+      report.push({ relPath: d.relPath, klass: d.klass, violations: [], skipped: true });
+      continue;
+    }
+    const skipChecks = new Set();
+    if (Array.isArray(vdSkipChecks)) {
+      for (const c of vdSkipChecks) skipChecks.add(String(c).trim());
+    }
+
+    const violations = [];
+
+    // Frontmatter applies to everything except 'skip'.
+    if (!skipChecks.has('frontmatter')) {
+      violations.push(...checkFrontmatter(d));
+    }
+
+    // Staleness applies if frontmatter parsed.
+    if (d.frontmatter.data && !skipChecks.has('stale')) {
+      violations.push(...checkStaleness(d, maxAge, today));
+    }
+
+    // Callout only on 'domain'.
+    if (d.klass === 'domain' && !skipChecks.has('callout')) {
+      violations.push(...checkCallout(d));
+    }
+
+    // Domain stem only on 'domain'.
+    if (d.klass === 'domain' && !skipChecks.has('domain-stem')) {
+      violations.push(...checkDomainStem(d));
+    }
+
+    // Doc length only on 'domain'. Context-efficiency signal — too-long docs
+    // burn the agent's budget on irrelevant sections.
+    if (d.klass === 'domain' && !skipChecks.has('length')) {
+      violations.push(...checkDocLength(d, maxDocLines));
+    }
+
+    // Wikilinks apply to everything except 'skip'.
+    if (!skipChecks.has('wikilink')) {
+      violations.push(...checkWikilinks(d, docsByStem));
+    }
+
+    report.push({ relPath: d.relPath, klass: d.klass, violations, skipped: false });
+  }
+
+  return { rootAbs, report };
+}
+
+// ---- Output -------------------------------------------------------------
+
+function printHuman(rootAbs, report) {
+  let totalViolations = 0;
+  let skippedCount = 0;
+  const sorted = [...report].sort((a, b) => a.relPath.localeCompare(b.relPath));
+  for (const r of sorted) {
+    if (r.skipped) {
+      console.log(`· ${r.relPath} (skipped via frontmatter vault-doctor: skip)`);
+      skippedCount++;
+      continue;
+    }
+    if (r.violations.length === 0) {
+      console.log(`✓ ${r.relPath}`);
+    } else {
+      for (const v of r.violations) {
+        console.log(`✗ ${r.relPath}: [${v.check}] ${v.detail}`);
+        totalViolations++;
+      }
+    }
+  }
+  console.log('');
+  const checked = report.length - skippedCount;
+  if (totalViolations === 0) {
+    console.log(`${checked} docs checked${skippedCount ? `, ${skippedCount} skipped` : ''}, 0 violations.`);
+  } else {
+    console.log(`${totalViolations} violation(s) across ${checked} doc(s)${skippedCount ? ` (${skippedCount} skipped)` : ''} in ${rootAbs}.`);
+  }
+  return totalViolations;
+}
+
+function printJson(rootAbs, report) {
+  let totalViolations = 0;
+  const violations = [];
+  for (const r of report) {
+    for (const v of r.violations) {
+      violations.push({ file: r.relPath, check: v.check, detail: v.detail });
+      totalViolations++;
+    }
+  }
+  const out = {
+    summary: {
+      root: rootAbs,
+      totalDocs: report.length,
+      violations: totalViolations,
+      exitCode: totalViolations === 0 ? 0 : 1,
+    },
+    violations,
+  };
+  console.log(JSON.stringify(out, null, 2));
+  return totalViolations;
+}
+
+// ---- Entry --------------------------------------------------------------
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    console.log(HELP);
+    return 0;
+  }
+  const root = args.root || path.join(process.cwd(), 'docs');
+  const { rootAbs, report } = await audit({
+    root,
+    maxAge: args.maxAge,
+    maxDocLines: args.maxDocLines,
+  });
+  const violations = args.json ? printJson(rootAbs, report) : printHuman(rootAbs, report);
+  return violations === 0 ? 0 : 1;
+}
+
+// Run main() only when executed directly (not when imported as a module
+// for tests). The path comparison handles Windows + symlinked entrypoints.
+const invokedDirectly = (() => {
+  try { return fileURLToPath(import.meta.url) === path.resolve(process.argv[1] || ''); }
+  catch { return false; }
+})();
+if (invokedDirectly) {
+  main().then(code => process.exit(code)).catch(err => {
+    console.error(`vault-doctor failed: ${err.message}`);
+    if (process.env.DEBUG) console.error(err.stack);
+    process.exit(2);
+  });
+}
+
+// Test-only exports. Not part of the CLI contract; do not depend on these
+// from outside `tests/`.
+export {
+  parseFrontmatter,
+  unquote,
+  classify,
+  slugifyHeading,
+  extractHeadings,
+  stripCode,
+  checkFrontmatter,
+  checkStaleness,
+  checkCallout,
+  checkDomainStem,
+  checkDocLength,
+  checkWikilinks,
+  WIKILINK_RE,
+};


### PR DESCRIPTION
Reaction to the 2026-05-17 cache-debugging incident. Sets up docs/ as an agent-readable vault with 5 written domain docs + 2 stubs, syncs stale CLAUDE.md / PRODUCT.md / DESIGN.md, and ships three new vault-tooling scripts.

The deploy.md doc specifically documents the CSS cache-busting discipline whose absence caused the 3-hour iPhone-cache debugging session.

`vault-doctor` clean. `check:claims` clean. `test:claims` 47/47. `build` clean.

**DO NOT MERGE until reviewed.** Master push triggers a DreamHost deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)