### PR TITLE
docs: sync stale references after booker launch

### DIFF
--- a/docs/contact-flow.md
+++ b/docs/contact-flow.md
@@ -19,7 +19,7 @@ verified-against:
 
 > **Also not in this doc:** the discovery-call booking widget added to `contact.html` on 2026-05-18 (a Google Calendar Appointment Schedule iframe). The booker bypasses `/api/contact` entirely — bookings write directly to William's Google Calendar and do not create a row in the WTSAdmin `contacts` table. The form path documented below is unchanged. Spec: `docs/superpowers/specs/2026-05-18-contact-booking-widget-design.md`. A v2 backlog item exists to mirror bookings into `contacts` via a Calendar-API poller.
 
-The contact form is the primary conversion path for cold traffic that doesn't book Calendly. PR #3 (`feat/contact-to-wtsadmin`, merged 2026-05-17) replaced the old Formspree integration with a direct write into the WTSAdmin Supabase database, an email notification to William, and an auto-reply to the lead. The whole thing runs through the `/api/contact` endpoint in `server.js`.
+The contact form is the fallback conversion path for visitors who'd rather write a message than book a discovery-call slot directly via the Google Appointment Schedule iframe added on 2026-05-18 (see top callout). PR #3 (`feat/contact-to-wtsadmin`, merged 2026-05-17) replaced the old Formspree integration with a direct write into the WTSAdmin Supabase database, an email notification to William, and an auto-reply to the lead. The whole thing runs through the `/api/contact` endpoint in `server.js`.
 
 ---
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -100,7 +100,7 @@ Secrets:
 Every HTML file's stylesheet link looks like this — `contact.html:19`:
 
 ```html
-<link rel="stylesheet" href="css/styles.css?v=20260517b" />
+<link rel="stylesheet" href="css/styles.css?v=20260518f" />
 ```
 
 The `?v=YYYYMMDDx` query string is the cache-buster. **Every commit that adds new Tailwind utility classes (or otherwise changes CSS output) MUST bump the version in lockstep, across all 8 HTML pages.**
@@ -126,7 +126,7 @@ When you ship any change that modifies CSS:
 4. Run `npm run build` to recompile `css/styles.css` so the new utilities are present.
 5. Commit both `*.html` and `css/styles.css` together.
 
-The 2026-05-17 incident's worst sub-failure was PR #8 only bumping `contact.html` (the file being edited) and leaving 7 pages on the previous `?v=`. Those 7 pages continued serving stale CSS to returning visitors until natural expiration. The current vault state has all 8 pages on `?v=20260517b` — **verify with the grep above before any new bump**.
+The 2026-05-17 incident's worst sub-failure was PR #8 only bumping `contact.html` (the file being edited) and leaving 7 pages on the previous `?v=`. Those 7 pages continued serving stale CSS to returning visitors until natural expiration. The current vault state has all 8 pages on `?v=20260518f` — **verify with the grep above before any new bump**.
 
 ### What does NOT need a bump
 


### PR DESCRIPTION
Followed `docs/_meta/docs-sync-prompt.md`. Ran `scripts/match-docs.mjs` against this session's diff (2a4f7a4..HEAD).

**Two real drifts fixed:**
- `docs/deploy.md` — cache-buster example + "current vault state" claim both said `?v=20260517b`. Now `?v=20260518f`.
- `docs/contact-flow.md` — preamble referenced Calendly (never integrated). Reframed the form as the fallback path for visitors who'd rather write than pick a slot in the live Google Appointment Schedule iframe.

**Concept-match noise (no doc edits needed):** chatbot.md, linter.md, pages.md (already synced), positioning.md, visual-system.md. All flagged because the cache-buster bump touched all 8 HTML files, but no doc-relevant content changed.

`docs/_backlog.md` has no new entries — every drift was verifiable and fixable inline.

No code touched; docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)