### PR TITLE
docs: sync v0.3 tooling + post-linkedin/discovery-call vault refresh

### DIFF
--- a/docs/_backlog.md
+++ b/docs/_backlog.md
@@ -2,7 +2,7 @@
 title: WTS Backlog
 domain: meta
 status: active
-last-reviewed: 2026-05-18
+last-reviewed: 2026-05-24
 ---
 
 # WTS Backlog
@@ -13,7 +13,28 @@ or silently fixing.
 
 ## Suspected drift
 
-_(empty at inception)_
+- **`pricing.html:84` still says "Free 30-Minute Discovery Call"** (the
+  big navy promo card H2 at the top of the page) — the 2026-05-18
+  copy-fix commit `e770f76` updated lines 233 and 275 ("Discovery card
+  subtitle + closing CTA blurb") but missed the hero promo card title.
+  Production currently has 30 in one place, 60 in two. Out of scope for
+  a docs sync (the rule is "do not touch files outside `docs/**` and
+  `docs/_backlog.md`"); needs a one-line copy fix on a separate branch.
+  When fixed, add a `discovery-call-duration` claim-linter pattern in
+  `scripts/check-claims.mjs` so a future drift in either direction trips
+  the build — same discipline as the other recurring-drift patterns.
+
+- **Brand assets shipped 2026-05-24 have no doc owner.** The `linkedin/`
+  directory (announcement.png + svg, banner.png + svg, preview.html) and
+  the refreshed `img/og-image.png` + new `img/og-image.svg` from commit
+  `89a1c66` are unmatched by `doc-ownership.yml`. Two options worth
+  picking one of: (a) extend `visual-system:` ownership to include
+  `img/og-image.*` and `linkedin/**`, with a short "Brand assets" section
+  added to `visual-system.md` listing each artifact and where it's used;
+  or (b) confirm these are out-of-band launch artifacts that legitimately
+  don't belong to any domain doc, and add a `coverage-exclude:` entry on
+  `visual-system.md`. Decide before the next docs sync — silence here
+  becomes the new precedent.
 
 ## Feature follow-ups
 
@@ -29,6 +50,16 @@ _(empty at inception)_
   `docs/superpowers/specs/2026-05-18-contact-booking-widget-design.md` §12.
 
 ## Tooling enhancements
+
+- **Try `vault-doctor --check-coverage` against the live vault.** Synced
+  in from `wts-ai-docs` v0.3 on 2026-05-24 alongside this entry. For
+  each domain doc with `paths:` in `doc-ownership.yml`, the check reports
+  source files matching the glob that the doc does not cite. Run it once
+  to surface gaps (`node scripts/vault-doctor.mjs --check-coverage`),
+  decide which findings are real vs noise, then opt the noisy ones out
+  per-doc via frontmatter `coverage-exclude:` / `coverage-extensions:`
+  before enabling `--enforce-coverage <pct>` in CI. See
+  `_meta/vault-conventions.md` §Coverage for the full rule.
 
 - **Document an emergency-deploy escape hatch.** If the linter false-positives
   and blocks a legitimate hot-fix deploy, the path forward is undocumented.

--- a/docs/_meta/doc-ownership.yml
+++ b/docs/_meta/doc-ownership.yml
@@ -3,11 +3,37 @@
 # Consumed by `scripts/match-docs.mjs` to determine which docs are affected
 # by a given diff. Edit this file to map your code paths to your domain docs.
 #
+# Format:
+#   docs:
+#     <doc-filename-without-md>:
+#       paths:                    # file globs (relative to repo root)
+#         - 'src/auth/**'
+#         - 'src/api/auth/**'
+#       concepts:                 # optional: keywords found in changed-file content
+#         - 'verifyAuthToken'
+#         - 'createBrowserClient'
+#       db_objects:               # optional: route SQL migration diffs to this doc
+#         - table: profiles       #   - matches CREATE/ALTER/DROP TABLE profiles
+#         - function: get_user    #   - matches CREATE FUNCTION get_user
+#         - rls: "all tables"     #   - matches ANY CREATE/ALTER/DROP POLICY
+#
+# Coverage check (vault-doctor --check-coverage):
+#   For each doc with `paths:`, the linter reports files matching the glob
+#   that are not cited (by literal path) anywhere in the doc body. By default
+#   this is informational only. Pass `--enforce-coverage <n>` to fail docs
+#   below n% coverage. Config/asset extensions (.md, .json, .svg, etc.) are
+#   exempt by default; per-doc override via frontmatter:
+#       coverage-extensions: [.ts, .tsx]    # allowlist mode
+#       coverage-exclude:    [src/legacy/api/foo.ts]
+#
 # Notes:
 # - A file can be matched by multiple docs. The script reports it under each.
 # - A file matched by NO doc is reported as "unmatched" — handle in step 3 of
 #   the sync workflow (add ownership, or confirm it legitimately has no owner).
 # - Globs are evaluated relative to the repo root.
+# - db_objects is opt-in: SQL routing only activates if at least one doc
+#   declares it. WTS doesn't currently use Supabase migrations, so no docs
+#   here declare db_objects yet — but the routing is available if needed.
 
 docs:
 

--- a/docs/_meta/vault-conventions.md
+++ b/docs/_meta/vault-conventions.md
@@ -2,7 +2,7 @@
 title: Vault Conventions
 domain: meta
 status: active
-last-reviewed: 2026-05-18
+last-reviewed: 2026-05-24
 ---
 
 # Vault Conventions
@@ -96,6 +96,28 @@ Any section citing schema, RLS policies, API shape, or live system state must:
 3. **Update the doc's frontmatter:** bump `last-reviewed` to today, add the relevant migration/spec to `verified-against:` if it's now load-bearing.
 
 If a section cannot be verified (tool unavailable, query ambiguous), add a `TODO verify: <what>` entry to `docs/_backlog.md` rather than guessing.
+
+## Coverage
+
+For docs with `paths:` declared in `doc-ownership.yml`, the linter
+(`vault-doctor --check-coverage`) reports source files in that glob that
+the doc does not cite. The unit is **files** (a path is "cited" iff it
+appears as a literal substring in the doc body — usually as a `file:line`
+reference inside backticks).
+
+Defaults:
+- Config/asset extensions (`.md`, `.json`, `.yml`, `.svg`, `.png`, …) are
+  exempt. Override per-doc via frontmatter:
+  - `coverage-extensions: [.ts, .tsx]` — allowlist (only these count).
+  - `coverage-exclude: [src/legacy/foo.ts]` — exempt specific files.
+- Output is informational (prefix `i`). To make low coverage a violation,
+  run with `--enforce-coverage <pct>`.
+- Frontmatter `vault-doctor-skip-checks: [coverage]` opts a doc out entirely.
+
+The check exists to catch the failure mode of "doc passes freshness and
+shape checks but silently covers half of its declared territory" — a
+hallucination risk because an agent reading the doc sees a clean health
+signal and may fabricate behavior for the undocumented files.
 
 ## Mermaid diagrams
 

--- a/docs/chatbot.md
+++ b/docs/chatbot.md
@@ -2,10 +2,10 @@
 title: Chatbot
 domain: chatbot
 status: active
-last-reviewed: 2026-05-18
+last-reviewed: 2026-05-24
 verified-against:
   - server: server.js:36-105 (/api/chat handler + prompt loader)
-  - prompt: prompts/chatbot-system.md (full content) on 2026-05-18
+  - prompt: prompts/chatbot-system.md (full content) on 2026-05-18; 30→60-min copy-fix only on 2026-05-24
   - widget: js/chatbot.js (floating widget) on 2026-05-18
   - widget: js/chatbot-demo.js (inline demo on small-business.html) on 2026-05-18
 ---
@@ -118,7 +118,7 @@ These are the textbook use case for `check-claims-allow`. See [[linter#suppressi
 
 **`prompts/chatbot-system.md` AND `pricing.html` both contain the canonical pricing.** They must match exactly. The linter doesn't catch numeric drift — agent discipline does.
 
-Pricing currently in lockstep (verified 2026-05-18):
+Pricing currently in lockstep (verified 2026-05-18; Track 3 Discovery duration corrected 2026-05-24):
 
 | Tier | Both surfaces say |
 |---|---|

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -2,9 +2,9 @@
 title: Positioning & Brand Voice
 domain: positioning
 status: active
-last-reviewed: 2026-05-18
+last-reviewed: 2026-05-24
 verified-against:
-  - source: 8 HTML pages on 2026-05-18
+  - source: 8 HTML pages on 2026-05-18; Track 3 Discovery duration row corrected 2026-05-24
   - prompt: prompts/chatbot-system.md
   - profile: D:/code/cv/PROFILE.md §10 framing rules
 ---

--- a/scripts/vault-doctor.mjs
+++ b/scripts/vault-doctor.mjs
@@ -35,6 +35,7 @@
 import { promises as fs } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
+import { loadOwnership, globToRegExp, compileOwnership } from './match-docs.mjs';
 
 const DEFAULT_MAX_AGE_DAYS = 60;
 const DEFAULT_MAX_DOC_LINES = 600;
@@ -56,6 +57,15 @@ OPTIONS
                           A long doc burns agent context budget; split or
                           extract a cheatsheet. Per-doc override: frontmatter
                           \`max-doc-lines: N\` (set to 0 to disable for that doc).
+  --check-coverage        Enable the coverage check: for each domain doc
+                          with paths declared in doc-ownership.yml, report
+                          which files in that glob are not cited in the doc.
+                          Off by default (opt-in).
+  --enforce-coverage <n>  Implies --check-coverage. Treat docs with file
+                          coverage below N% as violations (exit 1). Without
+                          this flag, coverage gaps are informational only.
+  --repo-root <path>      Path to repo root (where doc-ownership.yml's path
+                          globs are evaluated). Default: parent of --root.
   --json                  Emit machine-readable JSON instead of human text.
   --help, -h              Show this help.
 
@@ -64,6 +74,8 @@ ESCAPE HATCHES (frontmatter, per-doc)
   vault-doctor-skip-checks: [stale, wikilink]     # skip a subset
   max-age: 30                                     # override --max-age for this doc
   max-doc-lines: 800                              # override --max-doc-lines for this doc
+  coverage-extensions: [.ts, .tsx]                # restrict coverage to these exts only
+  coverage-exclude: [path/to/file.ts]             # exempt specific files from coverage
 
 INLINE ESCAPE HATCH (in doc body)
   See [[business#planned-section]] <!-- vault-doctor: ignore -->
@@ -81,6 +93,9 @@ function parseArgs(argv) {
     maxDocLines: DEFAULT_MAX_DOC_LINES,
     json: false,
     help: false,
+    checkCoverage: false,
+    enforceCoverage: null,  // null = report only; integer = % threshold
+    repoRoot: null,         // null = inferred from --root
   };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
@@ -95,7 +110,17 @@ function parseArgs(argv) {
       const n = parseInt(argv[++i], 10);
       if (!Number.isFinite(n) || n < 0) die(`--max-doc-lines must be a non-negative integer, got "${argv[i]}".`, 2);
       args.maxDocLines = n;
-    } else {
+    } else if (a === '--check-coverage') args.checkCoverage = true;
+    else if (a === '--enforce-coverage') {
+      const n = parseInt(argv[++i], 10);
+      if (!Number.isFinite(n) || n < 0 || n > 100) {
+        die(`--enforce-coverage must be an integer 0–100, got "${argv[i]}".`, 2);
+      }
+      args.enforceCoverage = n;
+      args.checkCoverage = true; // enforce implies enabled
+    }
+    else if (a === '--repo-root') args.repoRoot = argv[++i];
+    else {
       die(`Unknown argument: ${a}\nRun --help for usage.`, 2);
     }
   }
@@ -211,6 +236,37 @@ async function walk(dir, excludeDirs) {
     }
   }
   await recurse(dir);
+  return out;
+}
+
+const DEFAULT_REPO_EXCLUDES = new Set([
+  'node_modules', '.git', 'dist', 'build', 'out', '.next',
+  'coverage', 'bin', 'obj', '.venv', '__pycache__', 'target',
+]);
+
+// Walk a repo root (not the vault root). Returns posix-style relative paths.
+// Defaults (node_modules, .git, dist, etc.) are always applied. Pass
+// `excludeDirs` to add additional directories to exclude.
+async function walkRepo(repoRoot, excludeDirs = DEFAULT_REPO_EXCLUDES) {
+  const combined = new Set([...DEFAULT_REPO_EXCLUDES, ...excludeDirs]);
+  const out = [];
+  async function recurse(d, relPrefix) {
+    let entries;
+    try {
+      entries = await fs.readdir(d, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const ent of entries) {
+      if (ent.isDirectory()) {
+        if (combined.has(ent.name)) continue;
+        await recurse(path.join(d, ent.name), relPrefix ? `${relPrefix}/${ent.name}` : ent.name);
+      } else if (ent.isFile()) {
+        out.push(relPrefix ? `${relPrefix}/${ent.name}` : ent.name);
+      }
+    }
+  }
+  await recurse(repoRoot, '');
   return out;
 }
 
@@ -344,6 +400,59 @@ function checkDocLength(doc, defaultMax) {
   return [];
 }
 
+// Coverage check: for a domain doc with declared `paths` in
+// doc-ownership.yml, count how many files matching those paths are cited
+// (by literal path substring) anywhere in the doc body. Reports uncovered
+// files so an author can either document them or remove them from the doc's
+// territory.
+//
+// Citation detection is a literal substring match against the doc body
+// (after frontmatter). This is robust to formatting variation:
+//   - `src/api/auth/route.ts:42` (backticks + line)
+//   - `src/api/auth/route.ts` (backticks, no line)
+//   - src/api/auth/route.ts (bare in prose)
+// all match. False-positive risk is low; documents don't accidentally embed
+// realistic file paths.
+function checkCoverage(doc, ownedFiles) {
+  const total = ownedFiles.length;
+  if (total === 0) {
+    return { total: 0, cited: 0, uncovered: [], percent: 100 };
+  }
+  const cited = [];
+  const uncovered = [];
+  for (const f of ownedFiles) {
+    if (doc.body.includes(f)) {
+      cited.push(f);
+    } else {
+      uncovered.push(f);
+    }
+  }
+  const percent = Math.round((cited.length / total) * 100);
+  return { total, cited: cited.length, uncovered, percent };
+}
+
+const DEFAULT_COVERAGE_SKIP_EXTS = new Set([
+  '.md', '.json', '.yml', '.yaml', '.svg', '.png', '.jpg', '.jpeg',
+  '.gif', '.ico', '.css', '.scss', '.lock', '.txt',
+]);
+
+// Filter a list of repo-relative file paths down to those that should
+// require doc coverage. By default, drops configs/assets (see
+// DEFAULT_COVERAGE_SKIP_EXTS). When `opts.allow` is provided, switches to
+// allowlist mode: only files with those extensions are kept.
+function filterCoverageEligible(files, opts = {}) {
+  const allow = opts.allow
+    ? new Set(opts.allow.map(e => e.toLowerCase()))
+    : null;
+  return files.filter(f => {
+    const dot = f.lastIndexOf('.');
+    if (dot === -1 || dot < f.lastIndexOf('/')) return true; // no ext = keep
+    const ext = f.slice(dot).toLowerCase();
+    if (allow) return allow.has(ext);
+    return !DEFAULT_COVERAGE_SKIP_EXTS.has(ext);
+  });
+}
+
 // GitHub-style heading slug: lowercase, drop most punctuation, EACH whitespace
 // char → one hyphen (no collapsing — that's how GitHub renders "X & Y" as
 // `x--y`). Tested against real headings like:
@@ -463,8 +572,11 @@ async function loadDoc(absPath, rootAbs) {
   };
 }
 
-async function audit({ root, maxAge, maxDocLines }) {
+async function audit({ root, maxAge, maxDocLines, checkCoverage: coverageEnabled, enforceCoverage, repoRoot }) {
   const rootAbs = path.resolve(root);
+  const repoRootAbs = repoRoot
+    ? path.resolve(repoRoot)
+    : path.resolve(rootAbs, '..');
   let stat;
   try {
     stat = await fs.stat(rootAbs);
@@ -475,6 +587,26 @@ async function audit({ root, maxAge, maxDocLines }) {
 
   const files = await walk(rootAbs, new Set(['_archive']));
   const docs = await Promise.all(files.map(f => loadDoc(f, rootAbs)));
+
+  // Build per-doc owned-files lists once. Cheap when coverage is off (skipped
+  // entirely); when on, we walk the repo once and run each doc's globs.
+  let coverageByDoc = null; // Map<slug, string[]> (eligible owned files)
+  if (coverageEnabled) {
+    const ownershipPath = path.join(rootAbs, '_meta', 'doc-ownership.yml');
+    let ownershipLoad;
+    try {
+      ownershipLoad = await loadOwnership(ownershipPath);
+    } catch (err) {
+      die(`Coverage check enabled but could not load ownership file:\n  ${err.message}`, 2);
+    }
+    const compiled = compileOwnership(ownershipLoad.ownership);
+    const allFiles = await walkRepo(repoRootAbs);
+    coverageByDoc = new Map();
+    for (const { doc, pathRegexes } of compiled) {
+      const matched = allFiles.filter(f => pathRegexes.some(({ re }) => re.test(f)));
+      coverageByDoc.set(doc, matched);
+    }
+  }
 
   // Index by stem (filename without .md, relative path components joined with /).
   // Wikilinks use bare stems like [[auth]] or [[vault-conventions]] (without path),
@@ -499,7 +631,7 @@ async function audit({ root, maxAge, maxDocLines }) {
     const vdValue = d.frontmatter.data?.['vault-doctor'];
     const vdSkipChecks = d.frontmatter.data?.['vault-doctor-skip-checks'];
     if (vdValue === 'skip') {
-      report.push({ relPath: d.relPath, klass: d.klass, violations: [], skipped: true });
+      report.push({ relPath: d.relPath, klass: d.klass, violations: [], skipped: true, coverageResult: null });
       continue;
     }
     const skipChecks = new Set();
@@ -535,12 +667,39 @@ async function audit({ root, maxAge, maxDocLines }) {
       violations.push(...checkDocLength(d, maxDocLines));
     }
 
+    // Coverage (opt-in, domain docs only).
+    let coverageResult = null;
+    if (coverageEnabled && d.klass === 'domain' && !skipChecks.has('coverage')) {
+      const slug = path.basename(d.relPath, '.md');
+      const ownedRaw = coverageByDoc.get(slug) || [];
+      // Per-doc extension allowlist via frontmatter.
+      const allow = d.frontmatter.data?.['coverage-extensions'];
+      const filtered = filterCoverageEligible(
+        ownedRaw,
+        Array.isArray(allow) ? { allow } : {},
+      );
+      // Per-doc file-level exclusions.
+      const excludes = new Set(
+        Array.isArray(d.frontmatter.data?.['coverage-exclude'])
+          ? d.frontmatter.data['coverage-exclude']
+          : [],
+      );
+      const owned = filtered.filter(f => !excludes.has(f));
+      coverageResult = checkCoverage(d, owned);
+      if (enforceCoverage !== null && owned.length > 0 && coverageResult.percent < enforceCoverage) {
+        violations.push({
+          check: 'coverage',
+          detail: `${coverageResult.cited}/${coverageResult.total} files cited (${coverageResult.percent}%) — below threshold ${enforceCoverage}% — uncovered: ${coverageResult.uncovered.slice(0, 5).join(', ')}${coverageResult.uncovered.length > 5 ? `, +${coverageResult.uncovered.length - 5} more` : ''}`,
+        });
+      }
+    }
+
     // Wikilinks apply to everything except 'skip'.
     if (!skipChecks.has('wikilink')) {
       violations.push(...checkWikilinks(d, docsByStem));
     }
 
-    report.push({ relPath: d.relPath, klass: d.klass, violations, skipped: false });
+    report.push({ relPath: d.relPath, klass: d.klass, violations, skipped: false, coverageResult });
   }
 
   return { rootAbs, report };
@@ -566,6 +725,15 @@ function printHuman(rootAbs, report) {
         totalViolations++;
       }
     }
+    // Coverage INFO line (informational, doesn't count as a violation).
+    // Skipped for docs whose owned-files filter dropped everything (total 0).
+    if (r.coverageResult && r.coverageResult.total > 0) {
+      const cr = r.coverageResult;
+      const tail = cr.uncovered.length === 0
+        ? ''
+        : ` — uncovered: ${cr.uncovered.slice(0, 5).join(', ')}${cr.uncovered.length > 5 ? `, +${cr.uncovered.length - 5} more` : ''}`;
+      console.log(`i ${r.relPath}: [coverage] ${cr.cited}/${cr.total} files cited (${cr.percent}%)${tail}`);
+    }
   }
   console.log('');
   const checked = report.length - skippedCount;
@@ -580,10 +748,20 @@ function printHuman(rootAbs, report) {
 function printJson(rootAbs, report) {
   let totalViolations = 0;
   const violations = [];
+  const coverage = [];
   for (const r of report) {
     for (const v of r.violations) {
       violations.push({ file: r.relPath, check: v.check, detail: v.detail });
       totalViolations++;
+    }
+    if (r.coverageResult && r.coverageResult.total > 0) {
+      coverage.push({
+        file: r.relPath,
+        cited: r.coverageResult.cited,
+        total: r.coverageResult.total,
+        percent: r.coverageResult.percent,
+        uncovered: r.coverageResult.uncovered,
+      });
     }
   }
   const out = {
@@ -594,6 +772,7 @@ function printJson(rootAbs, report) {
       exitCode: totalViolations === 0 ? 0 : 1,
     },
     violations,
+    coverage,
   };
   console.log(JSON.stringify(out, null, 2));
   return totalViolations;
@@ -612,6 +791,9 @@ async function main() {
     root,
     maxAge: args.maxAge,
     maxDocLines: args.maxDocLines,
+    checkCoverage: args.checkCoverage,
+    enforceCoverage: args.enforceCoverage,
+    repoRoot: args.repoRoot,
   });
   const violations = args.json ? printJson(rootAbs, report) : printHuman(rootAbs, report);
   return violations === 0 ? 0 : 1;
@@ -634,6 +816,7 @@ if (invokedDirectly) {
 // Test-only exports. Not part of the CLI contract; do not depend on these
 // from outside `tests/`.
 export {
+  audit,
   parseFrontmatter,
   unquote,
   classify,
@@ -645,6 +828,11 @@ export {
   checkCallout,
   checkDomainStem,
   checkDocLength,
+  checkCoverage,
   checkWikilinks,
   WIKILINK_RE,
+  walkRepo,
+  DEFAULT_REPO_EXCLUDES,
+  filterCoverageEligible,
+  DEFAULT_COVERAGE_SKIP_EXTS,
 };


### PR DESCRIPTION
## Summary

Two-commit branch — tooling refresh from `wts-ai-docs` v0.3, then a docs sync covering everything since the last sync (`e7e287f`, 2026-05-18).

**Commit 1 — `chore(docs/tooling): sync vault-doctor v0.3 from wts-ai-docs`**
- `scripts/vault-doctor.mjs` upgraded (23.7 KB → 32 KB) — adds `--check-coverage` and `--enforce-coverage <pct>`.
- `docs/_meta/vault-conventions.md` — new `## Coverage` section.
- `docs/_meta/doc-ownership.yml` — expanded header docstring (format spec for `paths` / `concepts` / `db_objects`, plus coverage-check options). No ownership entries changed.

**Commit 2 — `docs: sync after 30→60-min copy fix + linkedin asset shipment`**
- `docs/chatbot.md` and `docs/positioning.md` — `last-reviewed` bumped to 2026-05-24; their `verified-against:` notes now record the 2026-05-24 Track 3 Discovery duration correction (the `e770f76` copy-fix touched these docs but left `last-reviewed` stale).
- `docs/_backlog.md` — 3 new entries (see below).

## New backlog entries — need decisions before merging downstream changes

1. **⚠ Production drift: `pricing.html:84`** still says *"Free 30-Minute Discovery Call"* in the navy promo H2. Commit `e770f76` updated lines 233 and 275 but missed the hero card. Production currently has 30 in one place, 60 in two. Out of scope to fix in a docs sync; needs a one-line copy fix on a separate branch + new `discovery-call-duration` claim-linter pattern so it can't drift again.

2. **Unmatched brand assets:** `linkedin/**` (announcement.png+svg, banner.png+svg, preview.html) and `img/og-image.*` (refreshed PNG + new SVG) have no doc owner. Two options laid out in the backlog:
   - Extend `visual-system:` ownership to include them, with a short "Brand assets" section listing each artifact and where it's used.
   - Confirm they're out-of-band launch artifacts that legitimately don't belong to any domain doc, and add `coverage-exclude:` on `visual-system.md`.

3. **Tooling follow-up:** try `node scripts/vault-doctor.mjs --check-coverage` against the live vault, decide what's real vs noise, opt the noisy ones out per-doc, then enable `--enforce-coverage <pct>` in CI.

## Out of scope

- Deploy CI not modified — vault-doctor isn't wired in `deploy.yml`. Existing `check:claims` job runs on this PR as usual.
- No HTML / chatbot prompt copy changed in either commit.
- Pre-existing local working-tree changes (`css/styles.css`, `img/apple-touch-icon_half_size.png`) deliberately not staged.

## Test plan

- [ ] `node scripts/vault-doctor.mjs` — confirm vault lints clean against the refreshed linter.
- [ ] `node scripts/vault-doctor.mjs --check-coverage` — informational; surface coverage gaps to decide which to enforce / suppress.
- [ ] `npm run check:claims` — should pass (no HTML/prompt touched).
- [ ] Visually review the two new commits' diffs.
- [ ] Decide on the two `_backlog.md` decisions before any merge of downstream PRs that would compound the drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)